### PR TITLE
[ADD] website_shift: personal page for working information

### DIFF
--- a/beesdoo_website_shift/__init__.py
+++ b/beesdoo_website_shift/__init__.py
@@ -1,1 +1,2 @@
 from . import controllers
+from . import models

--- a/beesdoo_website_shift/__openerp__.py
+++ b/beesdoo_website_shift/__openerp__.py
@@ -18,6 +18,8 @@
     'depends': ['website', 'beesdoo_shift'],
 
     'data': [
+        'data/res_config_data.xml',
         'views/shift_website_templates.xml',
+        'views/res_config_views.xml',
     ]
 }

--- a/beesdoo_website_shift/__openerp__.py
+++ b/beesdoo_website_shift/__openerp__.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
+
+# Copyright 2017-2018 Rémy Taymans <remytaymans@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 {
-    'name': 'Beescoop Shift Website',
+    'name': 'BEES coop Shift Website',
 
     'summary': """
         Show available shifts for regular and irregular workers in
@@ -10,16 +14,18 @@
     """,
 
     'author': 'Rémy Taymans',
+    'license': 'AGPL-3',
+    'version': '9.0.1.0',
     'website': "https://github.com/beescoop/Obeesdoo",
 
     'category': 'Cooperative management',
-    'version': '0.1',
 
     'depends': ['website', 'beesdoo_shift'],
 
     'data': [
         'data/res_config_data.xml',
         'views/shift_website_templates.xml',
+        'views/my_shift_website_templates.xml',
         'views/res_config_views.xml',
     ]
 }

--- a/beesdoo_website_shift/controllers/main.py
+++ b/beesdoo_website_shift/controllers/main.py
@@ -16,6 +16,8 @@ class WebsiteShiftController(http.Controller):
             return self.shift_irregular_worker()
         if working_mode == 'regular':
             return self.shift_template_regular_worker()
+        if working_mode == 'exempt':
+            return self.shift_exempted_worker()
 
         return request.render(
             'beesdoo_website_shift.shift',
@@ -122,5 +124,17 @@ class WebsiteShiftController(http.Controller):
                 'task_templates': task_templates,
                 'float_to_time': float_to_time,
                 'subscribed_shifts': subscribed_shifts,
+            }
+        )
+
+    def shift_exempted_worker(self, **kwargs):
+        # Get current user
+        cur_user = request.env['res.users'].browse(request.uid)
+
+        return request.render(
+            'beesdoo_website_shift.exempted_worker',
+            {
+                'partner': cur_user.partner_id,
+                'status': cur_user.partner_id.cooperative_status_ids,
             }
         )

--- a/beesdoo_website_shift/controllers/main.py
+++ b/beesdoo_website_shift/controllers/main.py
@@ -61,8 +61,8 @@ class WebsiteShiftController(http.Controller):
             {}
         )
 
-    @http.route('/shift/<model("beesdoo.shift.shift"):shift>/subscribe', auth='user', website=True)
-    def subscribe_to_shift(self, shift=None, **kw):
+    @http.route('/shift/<int:shift_id>/subscribe', auth='user', website=True)
+    def subscribe_to_shift(self, shift_id=-1, **kw):
         """
         Subscribe the current connected user into the given shift
         This is done only if :
@@ -73,6 +73,8 @@ class WebsiteShiftController(http.Controller):
         """
         # Get current user
         cur_user = request.env['res.users'].browse(request.uid)
+        # Get the shift
+        shift = request.env['beesdoo.shift.shift'].sudo().browse(shift_id)
         # Get config
         irregular_enable_sign_up = literal_eval(request.env['ir.config_parameter'].get_param(
             'beesdoo_website_shift.irregular_enable_sign_up'))

--- a/beesdoo_website_shift/controllers/main.py
+++ b/beesdoo_website_shift/controllers/main.py
@@ -300,6 +300,7 @@ class WebsiteShiftController(http.Controller):
                 subscribed_shifts.append(shift)
 
         return {
+            'is_regular': self.is_user_regular(),
             'subscribed_shifts': subscribed_shifts,
         }
 

--- a/beesdoo_website_shift/controllers/main.py
+++ b/beesdoo_website_shift/controllers/main.py
@@ -328,14 +328,14 @@ class WebsiteShiftController(http.Controller):
             past_shifts = request.env['beesdoo.shift.shift'].sudo().search(
                 [('start_time', '<=', now.strftime("%Y-%m-%d %H:%M:%S")),
                  ('worker_id', '=', cur_user.partner_id.id)],
-                order="start_time, task_template_id, task_type_id",
+                order="start_time desc, task_template_id, task_type_id",
                 limit=past_shift_limit,
             )
         else:
             past_shifts = request.env['beesdoo.shift.shift'].sudo().search(
                 [('start_time', '<=', now.strftime("%Y-%m-%d %H:%M:%S")),
                  ('worker_id', '=', cur_user.partner_id.id)],
-                order="start_time, task_template_id, task_type_id",
+                order="start_time desc, task_template_id, task_type_id",
             )
 
         return {

--- a/beesdoo_website_shift/controllers/main.py
+++ b/beesdoo_website_shift/controllers/main.py
@@ -8,13 +8,48 @@ from openerp.addons.beesdoo_shift.models.planning import float_to_time
 
 class WebsiteShiftController(http.Controller):
 
-    @http.route('/shift_irregular_worker', auth='public', website=True)
+    @http.route('/shift', auth='user', website=True)
+    def shift(self, **kwargs):
+        cur_user = request.env['res.users'].browse(request.uid)
+        working_mode = cur_user.partner_id.working_mode
+        if working_mode == 'irregular':
+            return self.shift_irregular_worker()
+        if working_mode == 'regular':
+            return self.shift_template_regular_worker()
+
+        return request.render(
+            'beesdoo_website_shift.shift',
+            {
+                'user': cur_user,
+            }
+        )
+
+    @http.route('/shift/<model("beesdoo.shift.shift"):shift>/subscribe', auth='user', website=True)
+    def subscribe_to_shift(self, shift=None, **kwargs):
+        # Get current user
+        cur_user = request.env['res.users'].browse(request.uid)
+        if (cur_user.partner_id.working_mode == 'irregular'
+                and shift
+                and not shift.worker_id):
+            shift.worker_id = cur_user.partner_id
+        return request.redirect(kwargs['nexturl'])
+
     def shift_irregular_worker(self, **kwargs):
+        # Get current user
+        cur_user = request.env['res.users'].browse(request.uid)
+
         # Get all the shifts in the future with no worker
         now = datetime.now()
         shifts = request.env['beesdoo.shift.shift'].sudo().search(
             [('start_time', '>', now.strftime("%Y-%m-%d %H:%M:%S")),
              ('worker_id', '=', False)],
+            order="start_time, task_template_id, task_type_id",
+        )
+
+        # Get shifts where user is subscribed
+        subscribed_shifts = request.env['beesdoo.shift.shift'].sudo().search(
+            [('start_time', '>', now.strftime("%Y-%m-%d %H:%M:%S")),
+             ('worker_id', '=', cur_user.partner_id.id)],
             order="start_time, task_template_id, task_type_id",
         )
 
@@ -31,24 +66,35 @@ class WebsiteShiftController(http.Controller):
         groupby_func = lambda s: (s.task_template_id, s.start_time, s.task_type_id)
         groupby_iter = groupby(shifts, groupby_func)
 
-        shifts_and_count = []
+        shifts_count_subscribed = []
         nb_displayed_shift = 0 # Number of shift displayed
         for (keys, grouped_shifts) in groupby_iter:
-            (task_template, _, _) = keys
+            (task_template, start_time, task_type) = keys
             nb_displayed_shift = nb_displayed_shift + 1
             s = list(grouped_shifts)
+            # Compute available space
             free_space = len(s)
+            # Is the current user subscribed to this task_template
+            is_subscribed = any(
+                (sub_shift.task_template_id == task_template and
+                 sub_shift.start_time == start_time and
+                 sub_shift.task_type_id == task_type)
+                for sub_shift in subscribed_shifts)
             if free_space >= task_template.worker_nb * hide_rule:
-                shifts_and_count.append([free_space, s[0]])
+                shifts_count_subscribed.append([s[0], free_space, is_subscribed])
             # Stop showing shifts if the limit is reached
             if irregular_shift_limit > 0 and nb_displayed_shift >= irregular_shift_limit:
                 break
 
         return request.render(
-            'beesdoo_website_shift.shift_template',
+            'beesdoo_website_shift.irregular_worker',
             {
-                'shift_templates': shifts_and_count,
+                'partner': cur_user.partner_id,
+                'status': cur_user.partner_id.cooperative_status_ids,
+                'shift_templates': shifts_count_subscribed,
                 'highlight_rule': highlight_rule,
+                'nexturl': '/shift',
+                'subscribed_shifts': subscribed_shifts,
             }
         )
 

--- a/beesdoo_website_shift/controllers/main.py
+++ b/beesdoo_website_shift/controllers/main.py
@@ -144,15 +144,17 @@ class WebsiteShiftController(http.Controller):
             irregular_enable_sign_up, nexturl
         ))
 
-        # Compute date before which the worker is up to date
-        today_date = fields.Date.from_string(cur_cooperative_status.today)
-        delta = (today_date - fields.Date.from_string(cur_cooperative_status.irregular_start_date)).days
-        date_before_last_shift = today_date + timedelta(days=(cur_cooperative_status.sr + 1) * PERIOD - delta % PERIOD)
-        date_before_last_shift = date_before_last_shift.strftime('%Y-%m-%d')
+        future_alert_date = False
+        if not cur_cooperative_status.alert_start_time:
+            # Compute date before which the worker is up to date
+            today_date = fields.Date.from_string(cur_cooperative_status.today)
+            delta = (today_date - fields.Date.from_string(cur_cooperative_status.irregular_start_date)).days
+            future_alert_date = today_date + timedelta(days=(cur_cooperative_status.sr + 1) * PERIOD - delta % PERIOD)
+            future_alert_date = future_alert_date.strftime('%Y-%m-%d')
 
         template_context.update(
             {
-                'date_before_last_shift': date_before_last_shift,
+                'future_alert_date': future_alert_date,
             }
         )
         return template_context

--- a/beesdoo_website_shift/controllers/main.py
+++ b/beesdoo_website_shift/controllers/main.py
@@ -1,4 +1,9 @@
 # -*- coding: utf8 -*-
+
+# Copyright 2017-2018 Rémy Taymans <remytaymans@gmail.com>
+# Copyright 2017-2018 Thibault François
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 from ast import literal_eval
 from datetime import datetime, timedelta
 from itertools import groupby
@@ -11,26 +16,57 @@ from openerp.addons.beesdoo_shift.models.planning import float_to_time
 
 class WebsiteShiftController(http.Controller):
 
-    @http.route('/shift', auth='user', website=True)
-    def shift(self, **kwargs):
-        cur_user = request.env['res.users'].browse(request.uid)
-        working_mode = cur_user.partner_id.working_mode
-        if working_mode == 'irregular':
-            return self.shift_irregular_worker()
-        if working_mode == 'regular':
-            return self.shift_template_regular_worker()
-        if working_mode == 'exempt':
-            return self.shift_exempted_worker()
+    def is_user_irregular(self):
+        user = request.env['res.users'].browse(request.uid)
+        working_mode = user.partner_id.working_mode
+        return working_mode == 'irregular'
+
+    def is_user_regular(self):
+        user = request.env['res.users'].browse(request.uid)
+        working_mode = user.partner_id.working_mode
+        return working_mode == 'regular'
+
+    def is_user_exempted(self):
+        user = request.env['res.users'].browse(request.uid)
+        working_mode = user.partner_id.working_mode
+        return working_mode == 'exempt'
+
+    @http.route('/my/shift', auth='user', website=True)
+    def my_shift(self, **kw):
+        """
+        Personnal page for managing your shifts
+        """
+        if self.is_user_irregular():
+            return request.render(
+                'beesdoo_website_shift.my_shift_irregular_worker',
+                self.my_shift_irregular_worker(nexturl='/my/shift')
+            )
+        if self.is_user_regular():
+            return request.render(
+                'beesdoo_website_shift.my_shift_regular_worker',
+                self.my_shift_regular_worker()
+            )
+        if self.is_user_exempted():
+            return request.render(
+                'beesdoo_website_shift.my_shift_exempted_worker',
+                self.my_shift_exempted_worker()
+            )
 
         return request.render(
-            'beesdoo_website_shift.shift',
-            {
-                'user': cur_user,
-            }
+            'beesdoo_website_shift.my_shift_non_worker',
+            {}
         )
 
     @http.route('/shift/<model("beesdoo.shift.shift"):shift>/subscribe', auth='user', website=True)
-    def subscribe_to_shift(self, shift=None, **kwargs):
+    def subscribe_to_shift(self, shift=None, **kw):
+        """
+        Subscribe the current connected user into the given shift
+        This is done only if :
+            * shift sign up is authorised via configuration panel
+            * the current connected user is an irregular worker
+            * the given shift exist
+            * the shift is free for subscription
+        """
         # Get current user
         cur_user = request.env['res.users'].browse(request.uid)
         # Get config
@@ -42,12 +78,111 @@ class WebsiteShiftController(http.Controller):
                 and shift
                 and not shift.worker_id):
             shift.worker_id = cur_user.partner_id
-        return request.redirect(kwargs['nexturl'])
+        return request.redirect(kw['nexturl'])
 
-    def shift_irregular_worker(self, **kwargs):
+    @http.route('/shift_irregular_worker', auth='public', website=True)
+    def public_shift_irregular_worker(self, **kw):
+        """
+        Show a public access page that show all the available shifts for irregular worker.
+        """
+        nexturl = '/shift_irregular_worker'
+        irregular_enable_sign_up = False
+
+        # Create template context
+        template_context = {}
+        template_context.update(self.available_shift_irregular_worker(
+            irregular_enable_sign_up, nexturl
+        ))
+
+        return request.render(
+            'beesdoo_website_shift.public_shift_irregular_worker',
+            template_context
+        )
+
+    @http.route('/shift_template_regular_worker', auth='public', website=True)
+    def public_shift_template_regular_worker(self, **kw):
+        """
+        Show a public access page that show all the available shift templates for regular worker.
+        """
+        # Get all the task template
+        template = request.env['beesdoo.shift.template']
+        task_templates = template.sudo().search([], order="planning_id, day_nb_id, start_time")
+
+        return request.render(
+            'beesdoo_website_shift.public_shift_template_regular_worker',
+            {
+                'task_templates': task_templates,
+                'float_to_time': float_to_time,
+            }
+        )
+
+    def my_shift_irregular_worker(self, nexturl=""):
+        """
+        Return template variables for 'beesdoo_website_shift.my_shift_irregular_worker' template
+        """
         # Get current user
         cur_user = request.env['res.users'].browse(request.uid)
         cur_cooperative_status = cur_user.partner_id.cooperative_status_ids
+
+        # Get config
+        irregular_enable_sign_up = literal_eval(request.env['ir.config_parameter'].get_param(
+            'beesdoo_website_shift.irregular_enable_sign_up'))
+
+        # Create template context
+        template_context = {}
+
+        template_context.update(self.my_shift_worker_status())
+        template_context.update(self.my_shift_next_shifts())
+        template_context.update(self.available_shift_irregular_worker(
+            irregular_enable_sign_up, nexturl
+        ))
+
+        # Compute date before which the worker is up to date
+        today_date = fields.Date.from_string(cur_cooperative_status.today)
+        delta = (today_date - fields.Date.from_string(cur_cooperative_status.irregular_start_date)).days
+        date_before_last_shift = today_date + timedelta(days=(cur_cooperative_status.sr + 1) * 28 - delta % 28)
+        date_before_last_shift = date_before_last_shift.strftime('%Y-%m-%d')
+
+        template_context.update(
+            {
+                'date_before_last_shift': date_before_last_shift,
+            }
+        )
+        return template_context
+
+    def my_shift_regular_worker(self):
+        """
+        Return template variables for 'beesdoo_website_shift.my_shift_regular_worker' template
+        """
+        # Create template context
+        template_context = {}
+
+        # Get all the task template
+        template = request.env['beesdoo.shift.template']
+        task_templates = template.sudo().search([], order="planning_id, day_nb_id, start_time")
+
+        template_context.update(self.my_shift_worker_status())
+        template_context.update(self.my_shift_next_shifts())
+        template_context.update(
+            {
+                'task_templates': task_templates,
+                'float_to_time': float_to_time,
+            }
+        )
+        return template_context
+
+    def my_shift_exempted_worker(self):
+        """
+        Return template variables for 'beesdoo_website_shift.my_shift_exempted_worker' template
+        """
+        return self.my_shift_worker_status()
+
+    def available_shift_irregular_worker(self, irregular_enable_sign_up=False, nexturl=""):
+        """
+        Return template variables for 'beesdoo_website_shift.available_shift_irregular_worker' template
+        """
+        # Get current user
+        cur_user = request.env['res.users'].browse(request.uid)
 
         # Get all the shifts in the future with no worker
         now = datetime.now()
@@ -64,12 +199,6 @@ class WebsiteShiftController(http.Controller):
             order="start_time, task_template_id, task_type_id",
         )
 
-        # Compute date before which the worker is up to date
-        today_date = fields.Date.from_string(cur_cooperative_status.today)
-        delta = (today_date - fields.Date.from_string(cur_cooperative_status.irregular_start_date)).days
-        date_before_last_shift = today_date + timedelta(days=(cur_cooperative_status.sr + 1) * 28 - delta % 28)
-        date_before_last_shift = date_before_last_shift.strftime('%Y-%m-%d')
-
         # Get config
         irregular_shift_limit = int(request.env['ir.config_parameter'].get_param(
             'beesdoo_website_shift.irregular_shift_limit'))
@@ -77,22 +206,23 @@ class WebsiteShiftController(http.Controller):
             'beesdoo_website_shift.highlight_rule'))
         hide_rule = int(request.env['ir.config_parameter'].get_param(
             'beesdoo_website_shift.hide_rule')) / 100.0
-        irregular_enable_sign_up = literal_eval(request.env['ir.config_parameter'].get_param(
-            'beesdoo_website_shift.irregular_enable_sign_up'))
 
         # Grouby task_template_id, if no task_template_id is specified
-        # then group by start_time
-        groupby_func = lambda s: (s.task_template_id, s.start_time, s.task_type_id)
-        groupby_iter = groupby(shifts, groupby_func)
+        # then group by start_time, if no start_time specified sort by
+        # task_type
+        groupby_iter = groupby(
+            shifts,
+            lambda s: (s.task_template_id, s.start_time, s.task_type_id)
+        )
 
         shifts_count_subscribed = []
         nb_displayed_shift = 0  # Number of shift displayed
         for (keys, grouped_shifts) in groupby_iter:
             (task_template, start_time, task_type) = keys
             nb_displayed_shift = nb_displayed_shift + 1
-            s = list(grouped_shifts)
+            shift_list = list(grouped_shifts)
             # Compute available space
-            free_space = len(s)
+            free_space = len(shift_list)
             # Is the current user subscribed to this task_template
             is_subscribed = any(
                 (sub_shift.task_template_id == task_template and
@@ -100,33 +230,24 @@ class WebsiteShiftController(http.Controller):
                  sub_shift.task_type_id == task_type)
                 for sub_shift in subscribed_shifts)
             if free_space >= task_template.worker_nb * hide_rule:
-                shifts_count_subscribed.append([s[0], free_space, is_subscribed])
+                shifts_count_subscribed.append([shift_list[0], free_space, is_subscribed])
             # Stop showing shifts if the limit is reached
             if irregular_shift_limit > 0 and nb_displayed_shift >= irregular_shift_limit:
                 break
 
-        return request.render(
-            'beesdoo_website_shift.irregular_worker',
-            {
-                'partner': cur_user.partner_id,
-                'status': cur_cooperative_status,
-                'date_before_last_shift': date_before_last_shift,
-                'shift_templates': shifts_count_subscribed,
-                'highlight_rule': highlight_rule,
-                'nexturl': '/shift',
-                'subscribed_shifts': subscribed_shifts,
-                'irregular_enable_sign_up': irregular_enable_sign_up,
-            }
-        )
+        return {
+            'shift_templates': shifts_count_subscribed,
+            'highlight_rule': highlight_rule,
+            'nexturl': nexturl,
+            'irregular_enable_sign_up': irregular_enable_sign_up,
+        }
 
-    def shift_template_regular_worker(self, **kwargs):
+    def my_shift_next_shifts(self):
+        """
+        Return template variables for 'beesdoo_website_shift.my_shift_next_shifts' template
+        """
         # Get current user
         cur_user = request.env['res.users'].browse(request.uid)
-
-        # Get all the task template
-        template = request.env['beesdoo.shift.template']
-        task_templates = template.sudo().search([], order="planning_id, day_nb_id, start_time")
-
         # Get shifts where user is subscribed
         now = datetime.now()
         subscribed_shifts = request.env['beesdoo.shift.shift'].sudo().search(
@@ -134,26 +255,15 @@ class WebsiteShiftController(http.Controller):
              ('worker_id', '=', cur_user.partner_id.id)],
             order="start_time, task_template_id, task_type_id",
         )
+        return {
+            'subscribed_shifts': subscribed_shifts,
+        }
 
-        return request.render(
-            'beesdoo_website_shift.regular_worker',
-            {
-                'partner': cur_user.partner_id,
-                'status': cur_user.partner_id.cooperative_status_ids,
-                'task_templates': task_templates,
-                'float_to_time': float_to_time,
-                'subscribed_shifts': subscribed_shifts,
-            }
-        )
-
-    def shift_exempted_worker(self, **kwargs):
-        # Get current user
+    def my_shift_worker_status(self):
+        """
+        Return template variables for 'beesdoo_website_shift.my_shift_worker_status_*' template
+        """
         cur_user = request.env['res.users'].browse(request.uid)
-
-        return request.render(
-            'beesdoo_website_shift.exempted_worker',
-            {
-                'partner': cur_user.partner_id,
-                'status': cur_user.partner_id.cooperative_status_ids,
-            }
-        )
+        return {
+            'status': cur_user.partner_id.cooperative_status_ids,
+        }

--- a/beesdoo_website_shift/controllers/main.py
+++ b/beesdoo_website_shift/controllers/main.py
@@ -6,7 +6,7 @@ from openerp.http import request
 
 from openerp.addons.beesdoo_shift.models.planning import float_to_time
 
-class ShiftPortalController(http.Controller):
+class WebsiteShiftController(http.Controller):
 
     @http.route('/shift_irregular_worker', auth='public', website=True)
     def shift_irregular_worker(self, **kwargs):
@@ -18,27 +18,37 @@ class ShiftPortalController(http.Controller):
             order="start_time, task_template_id, task_type_id",
         )
 
+        # Get config
+        irregular_shift_limit = int(request.env['ir.config_parameter'].get_param(
+            'beesdoo_website_shift.irregular_shift_limit'))
+        highlight_rule = int(request.env['ir.config_parameter'].get_param(
+            'beesdoo_website_shift.highlight_rule'))
+        hide_rule = int(request.env['ir.config_parameter'].get_param(
+            'beesdoo_website_shift.hide_rule')) / 100.0
+
         # Grouby task_template_id, if no task_template_id is specified
         # then group by start_time
         groupby_func = lambda s: (s.task_template_id, s.start_time, s.task_type_id)
         groupby_iter = groupby(shifts, groupby_func)
 
         shifts_and_count = []
+        nb_displayed_shift = 0 # Number of shift displayed
         for (keys, grouped_shifts) in groupby_iter:
             (task_template, _, _) = keys
+            nb_displayed_shift = nb_displayed_shift + 1
             s = list(grouped_shifts)
             free_space = len(s)
-            # Among shifts with at least 5 worker max, shows only shifts
-            # where there is at least two free spaces
-            if task_template.worker_nb > 5 and free_space >= 2:
+            if free_space >= task_template.worker_nb * hide_rule:
                 shifts_and_count.append([free_space, s[0]])
-            # Show available shifts if there is less than 5 worker max
-            if task_template.worker_nb <= 5:
-                shifts_and_count.append([free_space, s[0]])
+            # Stop showing shifts if the limit is reached
+            if irregular_shift_limit > 0 and nb_displayed_shift >= irregular_shift_limit:
+                break
 
-        return request.render('beesdoo_website_shift.shift_template',
+        return request.render(
+            'beesdoo_website_shift.shift_template',
             {
-                'shift_templates': shifts_and_count
+                'shift_templates': shifts_and_count,
+                'highlight_rule': highlight_rule,
             }
         )
 

--- a/beesdoo_website_shift/data/res_config_data.xml
+++ b/beesdoo_website_shift/data/res_config_data.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright 2017-2018 Rémy Taymans <remytaymans@gmail.com>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
 <openerp>
   <data noupdate="1">
     <record id="beesdoo_website_shift.irregular_shift_limit" model="ir.config_parameter">

--- a/beesdoo_website_shift/data/res_config_data.xml
+++ b/beesdoo_website_shift/data/res_config_data.xml
@@ -21,5 +21,13 @@
       <field name="key">beesdoo_website_shift.irregular_enable_sign_up</field>
       <field name="value">True</field>
     </record>
+    <record id="beesdoo_website_shift.irregular_past_shift_limit" model="ir.config_parameter">
+      <field name="key">beesdoo_website_shift.irregular_past_shift_limit</field>
+      <field name="value">10</field>
+    </record>
+    <record id="beesdoo_website_shift.regular_past_shift_limit" model="ir.config_parameter">
+      <field name="key">beesdoo_website_shift.regular_past_shift_limit</field>
+      <field name="value">10</field>
+    </record>
   </data>
 </openerp>

--- a/beesdoo_website_shift/data/res_config_data.xml
+++ b/beesdoo_website_shift/data/res_config_data.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data noupdate="1">
+    <record id="beesdoo_website_shift.irregular_shift_limit" model="ir.config_parameter">
+      <field name="key">beesdoo_website_shift.irregular_shift_limit</field>
+      <field name="value">0</field>
+    </record>
+    <record id="beesdoo_website_shift.highlight_rule" model="ir.config_parameter">
+      <field name="key">beesdoo_website_shift.highlight_rule</field>
+      <field name="value">3</field>
+    </record>
+    <record id="beesdoo_website_shift.hide_rule" model="ir.config_parameter">
+      <field name="key">beesdoo_website_shift.hide_rule</field>
+      <field name="value">20</field>
+    </record>
+  </data>
+</openerp>

--- a/beesdoo_website_shift/data/res_config_data.xml
+++ b/beesdoo_website_shift/data/res_config_data.xml
@@ -13,5 +13,9 @@
       <field name="key">beesdoo_website_shift.hide_rule</field>
       <field name="value">20</field>
     </record>
+    <record id="beesdoo_website_shift.irregular_enable_sign_up" model="ir.config_parameter">
+      <field name="key">beesdoo_website_shift.irregular_enable_sign_up</field>
+      <field name="value">True</field>
+    </record>
   </data>
 </openerp>

--- a/beesdoo_website_shift/data/res_config_data.xml
+++ b/beesdoo_website_shift/data/res_config_data.xml
@@ -29,5 +29,9 @@
       <field name="key">beesdoo_website_shift.regular_past_shift_limit</field>
       <field name="value">10</field>
     </record>
+    <record id="beesdoo_website_shift.regular_next_shift_limit" model="ir.config_parameter">
+      <field name="key">beesdoo_website_shift.regular_next_shift_limit</field>
+      <field name="value">13</field>
+    </record>
   </data>
 </openerp>

--- a/beesdoo_website_shift/i18n/fr_BE.po
+++ b/beesdoo_website_shift/i18n/fr_BE.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # 	* beesdoo_portal_shift
-# 
+#
 # Tanslators:
 # Rémy Taymans <remytaymans@gmail.com>, 2017
 msgid ""
@@ -77,7 +77,7 @@ msgstr "Créneaux"
 
 #. module: beesdoo_portal_shift
 #: model:ir.ui.view,arch_db:beesdoo_portal_shift.task_template
-msgid "Super Co-operator"
+msgid "Super Cooperator"
 msgstr "Super-coopérateur"
 
 #. module: beesdoo_portal_shift

--- a/beesdoo_website_shift/models/__init__.py
+++ b/beesdoo_website_shift/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_config

--- a/beesdoo_website_shift/models/res_config.py
+++ b/beesdoo_website_shift/models/res_config.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 
+from ast import literal_eval
 from openerp import fields, models, api
 
 PARAMS = [
     ('irregular_shift_limit', 'beesdoo_website_shift.irregular_shift_limit'),
     ('highlight_rule', 'beesdoo_website_shift.highlight_rule'),
     ('hide_rule', 'beesdoo_website_shift.hide_rule'),
+    ('irregular_enable_sign_up', 'beesdoo_website_shift.irregular_enable_sign_up'),
 ]
+
 
 class WebsiteShiftConfigSettings(models.TransientModel):
 
@@ -21,6 +24,9 @@ class WebsiteShiftConfigSettings(models.TransientModel):
     )
     hide_rule = fields.Integer(
         help="Treshold ((available space)/(max space)) in percentage of available space under wich the shift is hidden"
+    )
+    irregular_enable_sign_up = fields.Boolean(
+        help="Enable shift sign up for irregular worker"
     )
 
     @api.multi
@@ -48,4 +54,11 @@ class WebsiteShiftConfigSettings(models.TransientModel):
     def get_default_hide_rule(self):
         return {
             'hide_rule': int(self.env['ir.config_parameter'].get_param('beesdoo_website_shift.hide_rule'))
+        }
+
+    @api.multi
+    def get_default_irregular_shift_sign_up(self):
+        return {
+            'irregular_enable_sign_up': literal_eval(self.env['ir.config_parameter'].get_param(
+                'beesdoo_website_shift.irregular_enable_sign_up'))
         }

--- a/beesdoo_website_shift/models/res_config.py
+++ b/beesdoo_website_shift/models/res_config.py
@@ -13,6 +13,7 @@ PARAMS = [
     ('irregular_enable_sign_up', 'beesdoo_website_shift.irregular_enable_sign_up'),
     ('irregular_past_shift_limit', 'beesdoo_website_shift.irregular_past_shift_limit'),
     ('regular_past_shift_limit', 'beesdoo_website_shift.regular_past_shift_limit'),
+    ('regular_next_shift_limit', 'beesdoo_website_shift.regular_next_shift_limit'),
 ]
 
 
@@ -41,6 +42,9 @@ class WebsiteShiftConfigSettings(models.TransientModel):
     # Regular worker settings
     regular_past_shift_limit = fields.Integer(
         help="Maximum past shift that will be shown for regular worker"
+    )
+    regular_next_shift_limit = fields.Integer(
+        help="Maximun number of next shift that will be shown"
     )
 
     @api.multi
@@ -89,4 +93,11 @@ class WebsiteShiftConfigSettings(models.TransientModel):
         return {
             'regular_past_shift_limit': int(self.env['ir.config_parameter'].get_param(
                 'beesdoo_website_shift.regular_past_shift_limit'))
+        }
+
+    @api.multi
+    def get_default_regular_next_shift_limit(self):
+        return {
+            'regular_next_shift_limit': int(self.env['ir.config_parameter'].get_param(
+                'beesdoo_website_shift.regular_next_shift_limit'))
         }

--- a/beesdoo_website_shift/models/res_config.py
+++ b/beesdoo_website_shift/models/res_config.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+# Copyright 2017-2018 Rémy Taymans <remytaymans@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 from ast import literal_eval
 from openerp import fields, models, api
 

--- a/beesdoo_website_shift/models/res_config.py
+++ b/beesdoo_website_shift/models/res_config.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+from openerp import fields, models, api
+
+PARAMS = [
+    ('irregular_shift_limit', 'beesdoo_website_shift.irregular_shift_limit'),
+    ('highlight_rule', 'beesdoo_website_shift.highlight_rule'),
+    ('hide_rule', 'beesdoo_website_shift.hide_rule'),
+]
+
+class WebsiteShiftConfigSettings(models.TransientModel):
+
+    _name = 'beesdoo.website.shift.config.settings'
+    _inherit = 'res.config.settings'
+
+    irregular_shift_limit = fields.Integer(
+        help="Maximum shift that will be shown"
+    )
+    highlight_rule = fields.Integer(
+        help="Treshold of available space in a shift that trigger the highlight of the shift"
+    )
+    hide_rule = fields.Integer(
+        help="Treshold ((available space)/(max space)) in percentage of available space under wich the shift is hidden"
+    )
+
+    @api.multi
+    def set_params(self):
+        self.ensure_one()
+
+        for field_name, key_name in PARAMS:
+            value = getattr(self, field_name)
+            self.env['ir.config_parameter'].set_param(key_name, str(value))
+
+    @api.multi
+    def get_default_irregular_shift_limit(self):
+        return {
+            'irregular_shift_limit': int(self.env['ir.config_parameter'].get_param(
+                'beesdoo_website_shift.irregular_shift_limit'))
+        }
+
+    @api.multi
+    def get_default_highlight_rule(self):
+        return {
+            'highlight_rule': int(self.env['ir.config_parameter'].get_param('beesdoo_website_shift.highlight_rule'))
+        }
+
+    @api.multi
+    def get_default_hide_rule(self):
+        return {
+            'hide_rule': int(self.env['ir.config_parameter'].get_param('beesdoo_website_shift.hide_rule'))
+        }

--- a/beesdoo_website_shift/models/res_config.py
+++ b/beesdoo_website_shift/models/res_config.py
@@ -11,6 +11,8 @@ PARAMS = [
     ('highlight_rule', 'beesdoo_website_shift.highlight_rule'),
     ('hide_rule', 'beesdoo_website_shift.hide_rule'),
     ('irregular_enable_sign_up', 'beesdoo_website_shift.irregular_enable_sign_up'),
+    ('irregular_past_shift_limit', 'beesdoo_website_shift.irregular_past_shift_limit'),
+    ('regular_past_shift_limit', 'beesdoo_website_shift.regular_past_shift_limit'),
 ]
 
 
@@ -19,6 +21,7 @@ class WebsiteShiftConfigSettings(models.TransientModel):
     _name = 'beesdoo.website.shift.config.settings'
     _inherit = 'res.config.settings'
 
+    # Irregular worker settings
     irregular_shift_limit = fields.Integer(
         help="Maximum shift that will be shown"
     )
@@ -30,6 +33,14 @@ class WebsiteShiftConfigSettings(models.TransientModel):
     )
     irregular_enable_sign_up = fields.Boolean(
         help="Enable shift sign up for irregular worker"
+    )
+    irregular_past_shift_limit = fields.Integer(
+        help="Maximum past shift that will be shown for irregular worker"
+    )
+
+    # Regular worker settings
+    regular_past_shift_limit = fields.Integer(
+        help="Maximum past shift that will be shown for regular worker"
     )
 
     @api.multi
@@ -64,4 +75,18 @@ class WebsiteShiftConfigSettings(models.TransientModel):
         return {
             'irregular_enable_sign_up': literal_eval(self.env['ir.config_parameter'].get_param(
                 'beesdoo_website_shift.irregular_enable_sign_up'))
+        }
+
+    @api.multi
+    def get_default_irregular_past_shift_limit(self):
+        return {
+            'irregular_past_shift_limit': int(self.env['ir.config_parameter'].get_param(
+                'beesdoo_website_shift.irregular_past_shift_limit'))
+        }
+
+    @api.multi
+    def get_default_regular_past_shift_limit(self):
+        return {
+            'regular_past_shift_limit': int(self.env['ir.config_parameter'].get_param(
+                'beesdoo_website_shift.regular_past_shift_limit'))
         }

--- a/beesdoo_website_shift/views/my_shift_website_templates.xml
+++ b/beesdoo_website_shift/views/my_shift_website_templates.xml
@@ -116,6 +116,21 @@
 
     <div class="oe_structure"/>
 
+    <section class="wrap" t-if="is_regular">
+      <div class="container">
+        <div class="row">
+          <div class="col-md-12">
+            <div class="alert alert-warning">
+              <strong>Warning !</strong> For the moment public holidays are not taken into account. If your shift
+              occures during a public holiday, you do not have to do it.
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="oe_structure"/>
+
     <div class="visible-xs" t-foreach="subscribed_shifts" t-as="shift">
       <div class="panel panel-default">
         <div class="panel-heading clearfix">

--- a/beesdoo_website_shift/views/my_shift_website_templates.xml
+++ b/beesdoo_website_shift/views/my_shift_website_templates.xml
@@ -120,15 +120,15 @@
       <div class="panel panel-default">
         <div class="panel-heading clearfix">
           <div class="panel-title">
-            <t t-esc="time.strftime('%A %d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
-            <span t-field="shift.start_time" t-field-options='{"format": "HH:mm"}'/> -
-            <span t-field="shift.end_time" t-field-options='{"format": "HH:mm"}'/>
+            <t t-esc="'%s %s' % (shift.start_day, shift.start_date)"/>
+            <span t-esc="shift.start_time"/> -
+            <span t-esc="shift.end_time"/>
           </div>
         </div>
         <div class="panel-body">
-          <t t-esc="shift.task_type_id.name"/>
+          <t t-esc="shift.task_type_name"/>
           <button type="button" class="btn btn-default btn-sm pull-right"
-            t-if="shift.super_coop_id"
+            t-if="shift.super_coop_name"
             data-toggle="modal"
             t-att-data-target="'#super_coop-shift-%s' % shift.id">
             <span class="fa fa-info" aria-hidden="true"></span>
@@ -152,21 +152,21 @@
         <t t-foreach="subscribed_shifts" t-as="shift">
           <tr>
             <td>
-              <t t-esc="time.strftime('%A', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
+              <t t-esc="shift.start_day"/>
             </td>
             <td>
-              <t t-esc="time.strftime('%d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
+              <t t-esc="shift.start_date"/>
             </td>
             <td>
-              <span t-field="shift.start_time" t-field-options='{"format": "HH:mm"}'/> -
-              <span t-field="shift.end_time" t-field-options='{"format": "HH:mm"}'/>
+              <span t-esc="shift.start_time"/> -
+              <span t-esc="shift.end_time"/>
             </td>
             <td>
-              <t t-esc="shift.task_type_id.name"/>
+              <t t-esc="shift.task_type_name"/>
             </td>
             <td class="text-center">
               <button type="button" class="btn btn-default btn-sm"
-                t-if="shift.super_coop_id"
+                t-if="shift.super_coop_name"
                 data-toggle="modal"
                 t-att-data-target="'#super_coop-shift-%s' % shift.id">
                 <span class="fa fa-info" aria-hidden="true"></span>
@@ -179,7 +179,7 @@
 
     <!-- Super Co-operator info modal -->
     <t t-foreach="subscribed_shifts" t-as="shift">
-      <div class="modal fade" t-if="shift.super_coop_id" t-att-id="'super_coop-shift-%s' % shift.id" tabindex="-1" role="dialog"
+      <div class="modal fade" t-if="shift.super_coop_name" t-att-id="'super_coop-shift-%s' % shift.id" tabindex="-1" role="dialog"
         t-att-aria-labelledby="'super_coop-shift-%s-label' % shift.id">
         <div class="modal-dialog" role="document">
           <div class="modal-content">
@@ -188,14 +188,14 @@
                 <span aria-hidden="true">×</span>
               </button>
               <h4 class="modal-title" t-att-id="'super_coop-shift-%s-label' % shift.id">
-                <t t-esc="shift.super_coop_id.name"/>
+                <t t-esc="shift.super_coop_name"/>
               </h4>
             </div>
             <div class="modal-body">
-              <i class="fa fa-phone" aria-hidden="true"></i> <t t-esc="shift.super_coop_id.phone"/><br/>
+              <i class="fa fa-phone" aria-hidden="true"></i> <t t-esc="shift.super_coop_phone"/><br/>
               <i class="fa fa-envelope" aria-hidden="true"></i>
-              <a t-att-href="'mailto:%s' % shift.super_coop_id.email">
-                <t t-esc="shift.super_coop_id.email"/>
+              <a t-att-href="'mailto:%s' % shift.super_coop_email">
+                <t t-esc="shift.super_coop_email"/>
               </a>
             </div>
             <div class="modal-footer">

--- a/beesdoo_website_shift/views/my_shift_website_templates.xml
+++ b/beesdoo_website_shift/views/my_shift_website_templates.xml
@@ -84,13 +84,13 @@
       <t t-esc="dict(status.fields_get(allfields=['status'])['status']['selection'])[status.status]"/>
     </p>
 
-    <p t-if="status.holiday_start_time">
-      <label>Holiday start time:</label>
+    <p t-if="status.holiday_start_time and status.holiday_start_time > status.today or status.status == 'holiday'">
+      <label>Begin of Holiday:</label>
       <t t-esc="time.strftime('%A %d %B %Y', time.strptime(status.holiday_start_time, '%Y-%m-%d'))"/>
     </p>
 
-    <p t-if="status.holiday_end_time">
-      <label>Holiday end time:</label>
+    <p t-if="status.holiday_end_time and status.holiday_end_time > status.today or status.status == 'holiday'">
+      <label>End of Holiday:</label>
       <t t-esc="time.strftime('%A %d %B %Y', time.strptime(status.holiday_end_time, '%Y-%m-%d'))"/>
     </p>
 

--- a/beesdoo_website_shift/views/my_shift_website_templates.xml
+++ b/beesdoo_website_shift/views/my_shift_website_templates.xml
@@ -174,6 +174,91 @@
   </template>
 
   <template
+    id="my_shift_past_shifts"
+    name="My Shift : Past Shifts">
+
+    <div class="oe_structure"/>
+
+    <section class="wrap">
+      <div class="container">
+        <div class="row">
+          <div class="col-md-12">
+            <h2>
+              Your past shifts
+            </h2>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="oe_structure"/>
+
+    <div class="visible-xs" t-foreach="past_shifts" t-as="shift">
+      <div class="panel panel-default">
+        <div class="panel-heading clearfix">
+          <div class="panel-title">
+            <t t-esc="time.strftime('%A %d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
+            <span t-field="shift.start_time" t-field-options='{"format": "HH:mm"}'/> -
+            <span t-field="shift.end_time" t-field-options='{"format": "HH:mm"}'/>
+          </div>
+        </div>
+        <div class="panel-body">
+          <t t-esc="shift.task_type_id.name"/>
+        </div>
+      </div>
+    </div>
+
+    <table class="hidden-xs table table-striped" t-if="past_shifts">
+      <thead>
+        <tr>
+          <th>Day</th>
+          <th>Date</th>
+          <th>Time</th>
+          <th>Type of Shift</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        <t t-foreach="past_shifts" t-as="shift">
+          <tr>
+            <td>
+              <t t-esc="time.strftime('%A', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
+            </td>
+            <td>
+              <t t-esc="time.strftime('%d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
+            </td>
+            <td>
+              <span t-field="shift.start_time" t-field-options='{"format": "HH:mm"}'/> -
+              <span t-field="shift.end_time" t-field-options='{"format": "HH:mm"}'/>
+            </td>
+            <td>
+              <t t-esc="shift.task_type_id.name"/>
+            </td>
+            <td>
+              <t t-esc="shift.stage_id.name"/>
+            </td>
+          </tr>
+        </t>
+      </tbody>
+    </table>
+
+    <section class="wrap" t-if="not past_shifts">
+      <div class="container">
+        <div class="row">
+          <div class="col-md-12">
+            <div class="alert alert-info">
+              <strong>Info !</strong> You don't have any past shift.
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="oe_structure"/>
+
+  </template>
+
+  <template
     id="available_shift_irregular_worker"
     name="Available Shift for Irregular Worker">
 
@@ -434,6 +519,8 @@
 
               <t t-call="beesdoo_website_shift.my_shift_next_shifts"/>
 
+              <t t-call="beesdoo_website_shift.my_shift_past_shifts"/>
+
             </div> <!-- col-md-8 -->
           </div> <!-- row -->
         </div> <!-- container -->
@@ -518,6 +605,8 @@
               <div class="oe_structure"/>
 
               <t t-call="beesdoo_website_shift.available_shift_irregular_worker"/>
+
+              <t t-call="beesdoo_website_shift.my_shift_past_shifts"/>
 
             </div> <!-- col-md-8 -->
           </div> <!-- row -->

--- a/beesdoo_website_shift/views/my_shift_website_templates.xml
+++ b/beesdoo_website_shift/views/my_shift_website_templates.xml
@@ -76,7 +76,7 @@
     </p>
 
     <p t-if="status.super">
-      You are a Super Co-operator
+      You are a Super Cooperator
     </p>
 
     <p>
@@ -147,7 +147,7 @@
             data-toggle="modal"
             t-att-data-target="'#super_coop-shift-%s' % shift.id">
             <span class="fa fa-info" aria-hidden="true"></span>
-            Super Co-operator Info
+            Super Cooperator Info
           </button>
         </div>
       </div>
@@ -160,7 +160,7 @@
           <th>Date</th>
           <th>Time</th>
           <th>Type of Shift</th>
-          <th class="text-center">Super Co-operator Info</th>
+          <th class="text-center">Super Cooperator Info</th>
         </tr>
       </thead>
       <tbody>
@@ -192,7 +192,7 @@
       </tbody>
     </table>
 
-    <!-- Super Co-operator info modal -->
+    <!-- Super Cooperator info modal -->
     <t t-foreach="subscribed_shifts" t-as="shift">
       <div class="modal fade" t-if="shift.super_coop_name" t-att-id="'super_coop-shift-%s' % shift.id" tabindex="-1" role="dialog"
         t-att-aria-labelledby="'super_coop-shift-%s-label' % shift.id">

--- a/beesdoo_website_shift/views/my_shift_website_templates.xml
+++ b/beesdoo_website_shift/views/my_shift_website_templates.xml
@@ -618,9 +618,9 @@
                 <t t-esc="status.sr"/>
               </p>
 
-              <p t-if="date_before_last_shift">
-                <label>Date Before Last Shift:</label>
-                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(date_before_last_shift, '%Y-%m-%d'))"/>
+              <p t-if="future_alert_date">
+                <label>Future Date of Alert:</label>
+                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(future_alert_date, '%Y-%m-%d'))"/>
               </p>
 
               <p t-if="status.irregular_absence_date">

--- a/beesdoo_website_shift/views/my_shift_website_templates.xml
+++ b/beesdoo_website_shift/views/my_shift_website_templates.xml
@@ -75,6 +75,10 @@
       <t t-esc="dict(status.fields_get(allfields=['working_mode'])['working_mode']['selection'])[status.working_mode]"/>
     </p>
 
+    <p t-if="status.super">
+      You are a Super Co-operator
+    </p>
+
     <p>
       <label>Status:</label>
       <t t-esc="dict(status.fields_get(allfields=['status'])['status']['selection'])[status.status]"/>
@@ -123,6 +127,13 @@
         </div>
         <div class="panel-body">
           <t t-esc="shift.task_type_id.name"/>
+          <button type="button" class="btn btn-default btn-sm pull-right"
+            t-if="shift.super_coop_id"
+            data-toggle="modal"
+            t-att-data-target="'#super_coop-shift-%s' % shift.id">
+            <span class="fa fa-info" aria-hidden="true"></span>
+            Super Co-operator Info
+          </button>
         </div>
       </div>
     </div>
@@ -134,6 +145,7 @@
           <th>Date</th>
           <th>Time</th>
           <th>Type of Shift</th>
+          <th class="text-center">Super Co-operator Info</th>
         </tr>
       </thead>
       <tbody>
@@ -152,10 +164,47 @@
             <td>
               <t t-esc="shift.task_type_id.name"/>
             </td>
+            <td class="text-center">
+              <button type="button" class="btn btn-default btn-sm"
+                t-if="shift.super_coop_id"
+                data-toggle="modal"
+                t-att-data-target="'#super_coop-shift-%s' % shift.id">
+                <span class="fa fa-info" aria-hidden="true"></span>
+              </button>
+            </td>
           </tr>
         </t>
       </tbody>
     </table>
+
+    <!-- Super Co-operator info modal -->
+    <t t-foreach="subscribed_shifts" t-as="shift">
+      <div class="modal fade" t-if="shift.super_coop_id" t-att-id="'super_coop-shift-%s' % shift.id" tabindex="-1" role="dialog"
+        t-att-aria-labelledby="'super_coop-shift-%s-label' % shift.id">
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true">×</span>
+              </button>
+              <h4 class="modal-title" t-att-id="'super_coop-shift-%s-label' % shift.id">
+                <t t-esc="shift.super_coop_id.name"/>
+              </h4>
+            </div>
+            <div class="modal-body">
+              <i class="fa fa-phone" aria-hidden="true"></i> <t t-esc="shift.super_coop_id.phone"/><br/>
+              <i class="fa fa-envelope" aria-hidden="true"></i>
+              <a t-att-href="'mailto:%s' % shift.super_coop_id.email">
+                <t t-esc="shift.super_coop_id.email"/>
+              </a>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </t>
 
     <section class="wrap" t-if="not subscribed_shifts">
       <div class="container">

--- a/beesdoo_website_shift/views/my_shift_website_templates.xml
+++ b/beesdoo_website_shift/views/my_shift_website_templates.xml
@@ -1,0 +1,532 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright 2017-2018 Rémy Taymans <remytaymans@gmail.com>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<openerp>
+
+  <!-- Add menu entries -->
+  <template id="my_shift_link" name="Link to frontend portal" inherit_id="website.layout">
+    <xpath expr="//li[@id='o_logout']" position="before">
+      <li><a href="/my/shift" role="menuitem">My Shift</a></li>
+    </xpath>
+  </template>
+
+  <!-- Reusable templates -->
+  <template
+    id="my_shift_title"
+    name="My Shift Title">
+
+    <div class="oe_structure"/>
+
+    <section class="wrap">
+      <div class="container">
+        <div class="row">
+          <div class="col-md-12">
+            <h1 class="text-center">
+              Your shifts
+            </h1>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="oe_structure"/>
+
+  </template>
+
+  <template
+    id="my_shift_worker_status_title"
+    name="My Shift Worker Status Title">
+
+    <div class="oe_structure"/>
+
+    <section class="wrap">
+      <div class="container">
+        <div class="row">
+          <div class="col-md-12">
+            <h2>
+              Worker status
+              <span t-att-class="'label %s pull-right' % ('label-success' if status.can_shop else 'label-danger',)">
+                <span class="fa fa-shopping-cart"></span>
+                <t t-if="status.can_shop">
+                  <span class="fa fa-check"></span>
+                </t>
+                <t t-if="not status.can_shop">
+                  <span class="fa fa-times"></span>
+                </t>
+              </span>
+            </h2>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="oe_structure"/>
+
+  </template>
+
+  <template
+    id="my_shift_worker_status_common"
+    name="My Shift Worker Status Common">
+
+    <p>
+      <label>Working Mode:</label>
+      <t t-esc="dict(status.fields_get(allfields=['working_mode'])['working_mode']['selection'])[status.working_mode]"/>
+    </p>
+
+    <p>
+      <label>Status:</label>
+      <t t-esc="dict(status.fields_get(allfields=['status'])['status']['selection'])[status.status]"/>
+    </p>
+
+    <p t-if="status.holiday_start_time">
+      <label>Holiday start time:</label>
+      <t t-esc="time.strftime('%A %d %B %Y', time.strptime(status.holiday_start_time, '%Y-%m-%d'))"/>
+    </p>
+
+    <p t-if="status.holiday_end_time">
+      <label>Holiday end time:</label>
+      <t t-esc="time.strftime('%A %d %B %Y', time.strptime(status.holiday_end_time, '%Y-%m-%d'))"/>
+    </p>
+
+  </template>
+
+  <template
+    id="my_shift_next_shifts"
+    name="My Shift : Next Shifts">
+
+    <div class="oe_structure"/>
+
+    <section class="wrap">
+      <div class="container">
+        <div class="row">
+          <div class="col-md-12">
+            <h2>
+              Your next shifts
+            </h2>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="oe_structure"/>
+
+    <div class="visible-xs" t-foreach="subscribed_shifts" t-as="shift">
+      <div class="panel panel-default">
+        <div class="panel-heading clearfix">
+          <div class="panel-title">
+            <t t-esc="time.strftime('%A %d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
+            <span t-field="shift.start_time" t-field-options='{"format": "HH:mm"}'/> -
+            <span t-field="shift.end_time" t-field-options='{"format": "HH:mm"}'/>
+          </div>
+        </div>
+        <div class="panel-body">
+          <t t-esc="shift.task_type_id.name"/>
+        </div>
+      </div>
+    </div>
+
+    <table class="hidden-xs table table-striped" t-if="subscribed_shifts">
+      <thead>
+        <tr>
+          <th>Day</th>
+          <th>Date</th>
+          <th>Time</th>
+          <th>Type of Shift</th>
+        </tr>
+      </thead>
+      <tbody>
+        <t t-foreach="subscribed_shifts" t-as="shift">
+          <tr>
+            <td>
+              <t t-esc="time.strftime('%A', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
+            </td>
+            <td>
+              <t t-esc="time.strftime('%d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
+            </td>
+            <td>
+              <span t-field="shift.start_time" t-field-options='{"format": "HH:mm"}'/> -
+              <span t-field="shift.end_time" t-field-options='{"format": "HH:mm"}'/>
+            </td>
+            <td>
+              <t t-esc="shift.task_type_id.name"/>
+            </td>
+          </tr>
+        </t>
+      </tbody>
+    </table>
+
+    <section class="wrap" t-if="not subscribed_shifts">
+      <div class="container">
+        <div class="row">
+          <div class="col-md-12">
+            <div class="alert alert-warning">
+              <strong>Warning !</strong> You have not yet signed up to a shift.
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="oe_structure"/>
+
+  </template>
+
+  <template
+    id="available_shift_irregular_worker"
+    name="Available Shift for Irregular Worker">
+
+    <div class="oe_structure"/>
+
+    <div class="visible-xs" t-foreach="shift_templates" t-as="shift_count_subscribed">
+      <t t-set="shift" t-value="shift_count_subscribed[0]" />
+      <t t-set="count" t-value="shift_count_subscribed[1]" />
+      <t t-set="is_subscribed" t-value="shift_count_subscribed[2]" />
+      <t t-set="highlight_class" t-value="'panel-warning' if count >= highlight_rule else 'panel-default'"/>
+      <div t-att-class="'panel %s' % highlight_class">
+        <div class="panel-heading clearfix">
+          <div class="panel-title pull-left">
+            <t t-esc="time.strftime('%A %d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
+            <span t-field="shift.start_time" t-field-options='{"format": "HH:mm"}'/> -
+            <span t-field="shift.end_time" t-field-options='{"format": "HH:mm"}'/>
+          </div>
+          <div class="label label-default pull-right">
+            <t t-esc="count"/> space(s)
+          </div>
+        </div>
+        <div class="panel-body clearfix">
+          <t t-esc="shift.task_type_id.name"/>
+          <t t-if="is_subscribed">
+            <div class="label label-success pull-right">
+              <span class="fa fa-check" aria-hidden="true"></span>
+              Subscribed
+            </div>
+          </t>
+          <t t-if="irregular_enable_sign_up and not is_subscribed">
+            <button type="button" class="btn btn-default btn-sm pull-right" data-toggle="modal"
+              t-att-data-target="'#subscribe-shift-%s' % shift.id">
+              <span class="fa fa-user-plus" aria-hidden="true"></span>
+              Subscribe
+            </button>
+          </t>
+        </div>
+      </div>
+    </div>
+
+    <table class="hidden-xs table table-striped">
+      <thead>
+        <tr>
+          <th>Day</th>
+          <th>Date</th>
+          <th>Time</th>
+          <th>Type of Shift</th>
+          <th class="text-center">Available Spaces</th>
+          <th class="text-center" t-if="irregular_enable_sign_up">Subscribed</th>
+        </tr>
+      </thead>
+      <tbody>
+        <t t-foreach="shift_templates" t-as="shift_count_subscribed">
+          <t t-set="shift" t-value="shift_count_subscribed[0]" />
+          <t t-set="count" t-value="shift_count_subscribed[1]" />
+          <t t-set="is_subscribed" t-value="shift_count_subscribed[2]" />
+          <tr t-attf-class="{{ 'warning' if count >= highlight_rule else '' }}">
+            <td>
+              <t t-esc="time.strftime('%A', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
+            </td>
+            <td>
+              <t t-esc="time.strftime('%d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
+            </td>
+            <td>
+              <span t-field="shift.start_time" t-field-options='{"format": "HH:mm"}'/> -
+              <span t-field="shift.end_time" t-field-options='{"format": "HH:mm"}'/>
+            </td>
+            <td>
+              <t t-esc="shift.task_type_id.name"/>
+            </td>
+            <td class="text-center">
+              <t t-esc="count"/>
+            </td>
+            <td class="text-center" t-if="irregular_enable_sign_up">
+              <t t-if="is_subscribed">
+                <div class="label label-success">
+                  <span class="fa fa-check" aria-hidden="true"></span>
+                  Subscribed
+                </div>
+              </t>
+              <t t-if="not is_subscribed">
+                <button type="button" class="btn btn-default btn-sm" data-toggle="modal"
+                  t-att-data-target="'#subscribe-shift-%s' % shift.id">
+                  <span class="fa fa-user-plus" aria-hidden="true"></span>
+                  Subscribe
+                </button>
+              </t>
+            </td>
+          </tr>
+        </t>
+      </tbody>
+    </table>
+
+    <!-- Subscribe check -->
+    <t t-foreach="shift_templates" t-as="shift_count_subscribed">
+      <t t-set="shift" t-value="shift_count_subscribed[0]" />
+      <t t-set="count" t-value="shift_count_subscribed[1]" />
+      <t t-set="is_subscribed" t-value="shift_count_subscribed[2]" />
+      <div class="modal fade" t-att-id="'subscribe-shift-%s' % shift.id" tabindex="-1" role="dialog"
+        t-att-aria-labelledby="'subscribe-shift-%s-label' % shift.id">
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true">×</span>
+              </button>
+              <h4 class="modal-title" t-att-id="'subscribe-shift-%s-label' % shift.id">
+                Are you shure you want to subscribe to this shift?
+              </h4>
+            </div>
+            <div class="modal-body">
+              <t t-esc="time.strftime('%A', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
+              <t t-esc="time.strftime('%d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
+              <span t-field="shift.start_time" t-field-options='{"format": "HH:mm"}'/> -
+              <span t-field="shift.end_time" t-field-options='{"format": "HH:mm"}'/><br/>
+              <t t-esc="shift.task_type_id.name"/><br/>
+              <t t-esc="count"/> available space(s)
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+              <a class="btn btn-primary"
+                t-if="irregular_enable_sign_up"
+                t-att-href="'/shift/%s/subscribe?nexturl=%s' % (shift.id, nexturl)">
+                Subscribe
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </t>
+
+    <div class="oe_structure"/>
+
+  </template>
+
+  <!-- Shift for non-worker -->
+  <template
+    id="my_shift_non_worker"
+    name="My Shift for Non Worker"
+    page="True">
+    <t t-call="website.layout">
+
+      <t t-call="beesdoo_website_shift.my_shift_title"/>
+
+      <section class="wrap">
+        <div class="container">
+          <div class="row">
+            <div class="col-md-12">
+              <div class="alert alert-info">
+                You don't have to participate to shift system.
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div class="oe_structure"/>
+
+    </t>
+  </template>
+
+  <!-- Shifts Exempted Workers -->
+  <template
+    id="my_shift_exempted_worker"
+    name="My Shifts for Exempted Workers"
+    page="True">
+    <t t-call="website.layout">
+
+      <t t-call="beesdoo_website_shift.my_shift_title"/>
+
+      <section class="wrap">
+        <div class="container">
+          <div class="row">
+            <div class="col-xs-12 col-md-4 pull-right">
+
+              <t t-call="beesdoo_website_shift.my_shift_worker_status_title"/>
+
+              <t t-call="beesdoo_website_shift.my_shift_worker_status_common"/>
+
+              <p t-if="status.exempt_reason_id">
+                <label>Exempt Reason:</label>
+                <t t-esc="status.exempt_reason_id.name"/>
+              </p>
+
+              <div class="oe_structure"/>
+
+            </div>
+
+            <div class="col-xs-12 col-md-8">
+
+              <section class="wrap">
+                <div class="container">
+                  <div class="row">
+                    <div class="col-md-12">
+                      <div class="alert alert-info">
+                        You don't have to participate to shift system.
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <div class="oe_structure"/>
+
+            </div> <!-- col-md-8 -->
+          </div> <!-- row -->
+        </div> <!-- container -->
+      </section>
+
+      <div class="oe_structure"/>
+
+    </t>
+  </template>
+
+  <!-- Shifts for Regular Workers -->
+  <template
+    id="my_shift_regular_worker"
+    name="My Shifts for Regular Workers"
+    page="True">
+    <t t-call="website.layout">
+
+      <t t-call="beesdoo_website_shift.my_shift_title"/>
+
+      <section class="wrap">
+        <div class="container">
+          <div class="row">
+            <div class="col-xs-12 col-md-4 pull-right">
+
+              <t t-call="beesdoo_website_shift.my_shift_worker_status_title"/>
+
+              <t t-call="beesdoo_website_shift.my_shift_worker_status_common"/>
+
+              <p t-if="status.sr != 0">
+                <label>Shift in Advance:</label>
+                <t t-esc="status.sr"/>
+              </p>
+
+              <p t-if="status.sc != 0">
+                <label>Compensation Shift:</label>
+                <t t-esc="status.sc"/>
+              </p>
+
+              <p t-if="status.alert_start_time">
+                <label>In Alert Since:</label>
+                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(status.alert_start_time, '%Y-%m-%d'))"/>
+              </p>
+
+              <p t-if="status.extension_start_time">
+                <label>In Extension Since:</label>
+                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(status.extension_start_time, '%Y-%m-%d'))"/>
+              </p>
+
+              <div class="oe_structure"/>
+
+            </div>
+
+            <div class="col-xs-12 col-md-8">
+
+              <t t-call="beesdoo_website_shift.my_shift_next_shifts"/>
+
+            </div> <!-- col-md-8 -->
+          </div> <!-- row -->
+        </div> <!-- container -->
+      </section>
+
+      <div class="oe_structure"/>
+
+    </t>
+  </template>
+
+  <!-- Shifts for Irregular Workers -->
+  <template
+    id="my_shift_irregular_worker"
+    name="Shifts for Irregular Workers"
+    page="True">
+    <t t-call="website.layout">
+
+      <t t-call="beesdoo_website_shift.my_shift_title"/>
+
+      <section class="wrap">
+        <div class="container">
+          <div class="row">
+            <div class="col-xs-12 col-md-4 pull-right">
+
+              <t t-call="beesdoo_website_shift.my_shift_worker_status_title"/>
+
+              <t t-call="beesdoo_website_shift.my_shift_worker_status_common"/>
+
+              <p>
+                <label>Shift in Advance:</label>
+                <t t-esc="status.sr"/>
+              </p>
+
+              <p t-if="date_before_last_shift">
+                <label>Date Before Last Shift:</label>
+                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(date_before_last_shift, '%Y-%m-%d'))"/>
+              </p>
+
+              <p t-if="status.irregular_absence_date">
+                <label>Last Absence Date:</label>
+                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(status.irregular_absence_date, '%Y-%m-%d'))"/>
+              </p>
+
+              <p t-if="status.irregular_absence_counter">
+                <label>Number of Absence:</label>
+                <t t-esc="status.irregular_absence_counter"/>
+              </p>
+
+              <div class="oe_structure"/>
+
+            </div>
+
+            <div class="col-xs-12 col-md-8">
+
+              <t t-call="beesdoo_website_shift.my_shift_next_shifts"/>
+
+              <section class="wrap">
+                <div class="container">
+                  <div class="row">
+                    <div class="col-md-12">
+                      <h2>
+                        Available Shifts
+                      </h2>
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <div class="oe_structure"/>
+
+              <section class="wrap">
+                <div class="container">
+                  <div class="row">
+                    <div class="col-xs-12 col-sm-6">
+                      <p>
+                        Explanation text
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </section>
+              <div class="oe_structure"/>
+
+              <t t-call="beesdoo_website_shift.available_shift_irregular_worker"/>
+
+            </div> <!-- col-md-8 -->
+          </div> <!-- row -->
+        </div> <!-- container -->
+      </section>
+
+      <div class="oe_structure"/>
+
+    </t>
+  </template>
+
+</openerp>

--- a/beesdoo_website_shift/views/res_config_views.xml
+++ b/beesdoo_website_shift/views/res_config_views.xml
@@ -52,6 +52,10 @@
             <label for="regular_past_shift_limit"/>
             <field name="regular_past_shift_limit"/>
           </div>
+          <div>
+            <label for="regular_next_shift_limit"/>
+            <field name="regular_next_shift_limit"/>
+          </div>
         </form>
       </field>
     </record>

--- a/beesdoo_website_shift/views/res_config_views.xml
+++ b/beesdoo_website_shift/views/res_config_views.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright 2017-2018 Rémy Taymans <remytaymans@gmail.com>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
 <openerp>
   <data>
 
     <record id="view_website_shift_config_irregular" model="ir.ui.view">
-      <field name="name">Website Shift Settings</field>
+      <field name="name">Website Shift Settings Irregular Worker</field>
       <field name="model">beesdoo.website.shift.config.settings</field>
       <field name="arch" type="xml">
-        <form string="Configure Website Shift" class="oe_form_configuration">
+        <form string="Configure Website Shift Irregular Worker" class="oe_form_configuration">
           <header>
             <button string="Apply" type="object" name="execute" class="oe_highlight"/>
             <button string="Cancel" type="object" name="cancel" class="oe_link" special="cancel"/>
@@ -31,8 +35,8 @@
       </field>
     </record>
 
-    <record id="action_website_shift_configuration" model="ir.actions.act_window">
-      <field name="name">Website Shift Settings</field>
+    <record id="action_website_shift_config_irregular" model="ir.actions.act_window">
+      <field name="name">Website Shift Settings Irregular Worker</field>
       <field name="res_model">beesdoo.website.shift.config.settings</field>
       <field name="view_id" ref="view_website_shift_config_irregular"/>
       <field name="view_mode">form</field>
@@ -48,7 +52,7 @@
     <menuitem
       id="menu_website_shift_irregular"
       name="Irregular Shift"
-      action="action_website_shift_configuration"
+      action="action_website_shift_config_irregular"
       parent="menu_website_shift_root"
       sequence="1"/>
 

--- a/beesdoo_website_shift/views/res_config_views.xml
+++ b/beesdoo_website_shift/views/res_config_views.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+
+    <record id="view_website_shift_config_irregular" model="ir.ui.view">
+      <field name="name">Website Shift Settings</field>
+      <field name="model">beesdoo.website.shift.config.settings</field>
+      <field name="arch" type="xml">
+        <form string="Configure Website Shift" class="oe_form_configuration">
+          <header>
+            <button string="Apply" type="object" name="execute" class="oe_highlight"/>
+            <button string="Cancel" type="object" name="cancel" class="oe_link" special="cancel"/>
+          </header>
+          <div>
+            <label for="irregular_shift_limit"/>
+            <field name="irregular_shift_limit"/>
+          </div>
+          <div>
+            <label for="highlight_rule"/>
+            <field name="highlight_rule"/>
+          </div>
+          <div>
+            <label for="hide_rule"/>
+            <field name="hide_rule"/>
+          </div>
+        </form>
+      </field>
+    </record>
+
+    <record id="action_website_shift_configuration" model="ir.actions.act_window">
+      <field name="name">Website Shift Settings</field>
+      <field name="res_model">beesdoo.website.shift.config.settings</field>
+      <field name="view_id" ref="view_website_shift_config_irregular"/>
+      <field name="view_mode">form</field>
+      <field name="target">inline</field>
+    </record>
+
+    <menuitem
+      id="menu_website_shift_root"
+      name="Shift"
+      parent="website.menu_website_configuration"
+      sequence="20"/>
+
+    <menuitem
+      id="menu_website_shift_irregular"
+      name="Irregular Shift"
+      action="action_website_shift_configuration"
+      parent="menu_website_shift_root"
+      sequence="1"/>
+
+  </data>
+</openerp>

--- a/beesdoo_website_shift/views/res_config_views.xml
+++ b/beesdoo_website_shift/views/res_config_views.xml
@@ -31,6 +31,27 @@
             <label for="irregular_enable_sign_up"/>
             <field name="irregular_enable_sign_up"/>
           </div>
+          <div>
+            <label for="irregular_past_shift_limit"/>
+            <field name="irregular_past_shift_limit"/>
+          </div>
+        </form>
+      </field>
+    </record>
+
+    <record id="view_website_shift_config_regular" model="ir.ui.view">
+      <field name="name">Website Shift Settings Regular Worker</field>
+      <field name="model">beesdoo.website.shift.config.settings</field>
+      <field name="arch" type="xml">
+        <form string="Configure Website Shift Regular Worker" class="oe_form_configuration">
+          <header>
+            <button string="Apply" type="object" name="execute" class="oe_highlight"/>
+            <button string="Cancel" type="object" name="cancel" class="oe_link" special="cancel"/>
+          </header>
+          <div>
+            <label for="regular_past_shift_limit"/>
+            <field name="regular_past_shift_limit"/>
+          </div>
         </form>
       </field>
     </record>
@@ -39,6 +60,14 @@
       <field name="name">Website Shift Settings Irregular Worker</field>
       <field name="res_model">beesdoo.website.shift.config.settings</field>
       <field name="view_id" ref="view_website_shift_config_irregular"/>
+      <field name="view_mode">form</field>
+      <field name="target">inline</field>
+    </record>
+
+    <record id="action_website_shift_config_regular" model="ir.actions.act_window">
+      <field name="name">Website Shift Settings Regular Worker</field>
+      <field name="res_model">beesdoo.website.shift.config.settings</field>
+      <field name="view_id" ref="view_website_shift_config_regular"/>
       <field name="view_mode">form</field>
       <field name="target">inline</field>
     </record>
@@ -55,6 +84,13 @@
       action="action_website_shift_config_irregular"
       parent="menu_website_shift_root"
       sequence="1"/>
+
+    <menuitem
+      id="menu_website_shift_regular"
+      name="Regular Shift"
+      action="action_website_shift_config_regular"
+      parent="menu_website_shift_root"
+      sequence="10"/>
 
   </data>
 </openerp>

--- a/beesdoo_website_shift/views/res_config_views.xml
+++ b/beesdoo_website_shift/views/res_config_views.xml
@@ -23,6 +23,10 @@
             <label for="hide_rule"/>
             <field name="hide_rule"/>
           </div>
+          <div>
+            <label for="irregular_enable_sign_up"/>
+            <field name="irregular_enable_sign_up"/>
+          </div>
         </form>
       </field>
     </record>

--- a/beesdoo_website_shift/views/shift_website_templates.xml
+++ b/beesdoo_website_shift/views/shift_website_templates.xml
@@ -17,8 +17,8 @@
   </data>
 
   <!-- Available Tasks Templates for Regular Workers -->
-  <template 
-    id="task_template" 
+  <template
+    id="task_template"
     name="Available Tasks Templates for Regular Workers"
     page="True">
     <t t-call="website.layout">
@@ -64,7 +64,7 @@
             <div class="visible-xs" t-foreach="task_templates" t-as="template">
               <ul class="list-group">
                 <li class="list-group-item">
-                  <t t-esc="template.planning_id.name"/> : 
+                  <t t-esc="template.planning_id.name"/> :
                   <t t-esc="template.day_nb_id.name"/>
                   <t t-esc='float_to_time(template.start_time)' /> -
                   <t t-esc='float_to_time(template.end_time)'/>
@@ -142,8 +142,8 @@
   </template>
 
   <!-- Available shifts for irregular workers -->
-  <template 
-    id="shift_template" 
+  <template
+    id="shift_template"
     name="Available Shifts for Irregular Workers"
     page="True">
     <t t-call="website.layout">
@@ -186,12 +186,12 @@
               <t t-set="count" t-value="shift_and_count[0]" />
               <t t-set="shift" t-value="shift_and_count[1]" />
               <ul class="list-group">
-                <li class="list-group-item">
+                <li t-attf-class="{{ 'list-group-item list-group-item-danger' if count >= highlight_rule else 'list-group-item' }}">
                   <t t-esc="time.strftime('%A %d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
                   <span t-field="shift.start_time" t-field-options='{"format": "HH:mm"}'/> -
                   <span t-field="shift.end_time" t-field-options='{"format": "HH:mm"}'/>
                 </li>
-                <li class="list-group-item">
+                <li t-attf-class="{{ 'list-group-item list-group-item-danger' if count >= highlight_rule else 'list-group-item' }}">
                   <t t-esc="shift.task_type_id.name"/>
                   <span class="badge">
                     <t t-esc="count"/> space(s)
@@ -215,7 +215,7 @@
                 <t t-foreach="shift_templates" t-as="shift_and_count">
                   <t t-set="count" t-value="shift_and_count[0]" />
                   <t t-set="shift" t-value="shift_and_count[1]" />
-                  <tr>
+                  <tr t-attf-class="{{ 'danger' if count >= highlight_rule else '' }}">
                     <td>
                       <t t-esc="time.strftime('%A', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
                     </td>

--- a/beesdoo_website_shift/views/shift_website_templates.xml
+++ b/beesdoo_website_shift/views/shift_website_templates.xml
@@ -536,7 +536,7 @@
                 </div>
               </div>
 
-              <table class="hidden-xs table table-striped">
+              <table class="hidden-xs table table-striped" t-if="subscribed_shifts">
                 <thead>
                   <tr>
                     <th>Day</th>
@@ -630,7 +630,7 @@
                         Subscribed
                       </div>
                     </t>
-                    <t t-if="not is_subscribed">
+                    <t t-if="irregular_enable_sign_up and not is_subscribed">
                       <button type="button" class="btn btn-default btn-sm pull-right" data-toggle="modal"
                         t-att-data-target="'#subscribe-shift-%s' % shift.id">
                         <span class="fa fa-user-plus" aria-hidden="true"></span>
@@ -649,7 +649,7 @@
                     <th>Time</th>
                     <th>Type of Shift</th>
                     <th class="text-center">Available Spaces</th>
-                    <th class="text-center">Subscribed</th>
+                    <th class="text-center" t-if="irregular_enable_sign_up">Subscribed</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -674,7 +674,7 @@
                       <td class="text-center">
                         <t t-esc="count"/>
                       </td>
-                      <td class="text-center">
+                      <td class="text-center" t-if="irregular_enable_sign_up">
                         <t t-if="is_subscribed">
                           <div class="label label-success">
                             <span class="fa fa-check" aria-hidden="true"></span>
@@ -722,6 +722,7 @@
                       <div class="modal-footer">
                         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                         <a class="btn btn-primary"
+                           t-if="irregular_enable_sign_up"
                            t-att-href="'/shift/%s/subscribe?nexturl=%s' % (shift.id, nexturl)">
                           Subscribe
                         </a>

--- a/beesdoo_website_shift/views/shift_website_templates.xml
+++ b/beesdoo_website_shift/views/shift_website_templates.xml
@@ -45,7 +45,7 @@
             <div class="col-md-12">
               <p class="text-center">
                 Subscribe via the member office or via
-                <a href="mailto:volant@bees-coop.be">volant@bees-coop.be</a>
+                <a href="mailto:membre@bees-coop.be">membre@bees-coop.be</a>
               </p>
             </div>
           </div>

--- a/beesdoo_website_shift/views/shift_website_templates.xml
+++ b/beesdoo_website_shift/views/shift_website_templates.xml
@@ -49,6 +49,101 @@
     </t>
   </template>
 
+  <!-- Shifts Exempt Workers -->
+  <template
+    id="exempted_worker"
+    name="Shifts for Exempted Workers"
+    page="True">
+    <t t-call="website.layout">
+
+      <div class="oe_structure"/>
+
+      <section class="wrap">
+        <div class="container">
+          <div class="row">
+            <div class="col-md-12">
+              <h1 class="text-center">
+                Your shifts
+              </h1>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div class="oe_structure"/>
+
+      <section class="wrap">
+        <div class="container">
+          <div class="row">
+            <div class="col-xs-12 col-md-4 pull-right">
+
+              <section class="wrap">
+                <div class="container">
+                  <div class="row">
+                    <div class="col-md-12">
+                      <h2>
+                        Worker status
+                      </h2>
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <div class="oe_structure"/>
+
+              <p>
+                <label>Working Mode:</label>
+                <t t-esc="dict(status.fields_get(allfields=['working_mode'])['working_mode']['selection'])[status.working_mode]"/>
+              </p>
+              <p>
+                <label>Status:</label>
+                <t t-esc="dict(status.fields_get(allfields=['status'])['status']['selection'])[status.status]"/>
+              </p>
+              <p>
+                <label>Exempt Reason:</label>
+                <t t-esc="status.exempt_reason_id.name"/>
+              </p>
+              <t t-if="status.holiday_start_time">
+                <p>
+                  <label>Holiday start time:</label>
+                  <t t-esc="status.holiday_start_time"/>
+                </p>
+                <p>
+                  <label>Holiday end time:</label>
+                  <t t-esc="status.holiday_end_time"/>
+                </p>
+              </t>
+
+              <div class="oe_structure"/>
+
+            </div>
+
+            <div class="col-xs-12 col-md-8">
+
+              <section class="wrap">
+                <div class="container">
+                  <div class="row">
+                    <div class="col-md-12">
+                      <div class="alert alert-info">
+                        You don't have to participate to shift system.
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <div class="oe_structure"/>
+
+            </div> <!-- col-md-8 -->
+          </div> <!-- row -->
+        </div> <!-- container -->
+      </section>
+
+      <div class="oe_structure"/>
+
+    </t>
+  </template>
+
   <!-- Shifts for Regular Workers -->
   <template
     id="regular_worker"

--- a/beesdoo_website_shift/views/shift_website_templates.xml
+++ b/beesdoo_website_shift/views/shift_website_templates.xml
@@ -83,6 +83,15 @@
                     <div class="col-md-12">
                       <h2>
                         Worker status
+                        <span t-att-class="'label %s pull-right' % ('label-success' if status.can_shop else 'label-danger',)">
+                          <span class="fa fa-shopping-cart"></span>
+                          <t t-if="status.can_shop">
+                            <span class="fa fa-check"></span>
+                          </t>
+                          <t t-if="not status.can_shop">
+                            <span class="fa fa-times"></span>
+                          </t>
+                        </span>
                       </h2>
                     </div>
                   </div>
@@ -178,6 +187,15 @@
                     <div class="col-md-12">
                       <h2>
                         Worker status
+                        <span t-att-class="'label %s pull-right' % ('label-success' if status.can_shop else 'label-danger',)">
+                          <span class="fa fa-shopping-cart"></span>
+                          <t t-if="status.can_shop">
+                            <span class="fa fa-check"></span>
+                          </t>
+                          <t t-if="not status.can_shop">
+                            <span class="fa fa-times"></span>
+                          </t>
+                        </span>
                       </h2>
                     </div>
                   </div>
@@ -430,6 +448,15 @@
                     <div class="col-md-12">
                       <h2>
                         Worker status
+                        <span t-att-class="'label %s pull-right' % ('label-success' if status.can_shop else 'label-danger',)">
+                          <span class="fa fa-shopping-cart"></span>
+                          <t t-if="status.can_shop">
+                            <span class="fa fa-check"></span>
+                          </t>
+                          <t t-if="not status.can_shop">
+                            <span class="fa fa-times"></span>
+                          </t>
+                        </span>
                       </h2>
                     </div>
                   </div>

--- a/beesdoo_website_shift/views/shift_website_templates.xml
+++ b/beesdoo_website_shift/views/shift_website_templates.xml
@@ -328,8 +328,8 @@
               <section class="wrap">
                 <div class="container">
                   <div class="row">
-                    <div class="col-md-12">
-                      <p class="text-center">
+                    <div class="col-xs-12 col-sm-6">
+                      <p>
                         Explanation text
                       </p>
                     </div>
@@ -606,8 +606,8 @@
               <section class="wrap">
                 <div class="container">
                   <div class="row">
-                    <div class="col-md-12">
-                      <p class="text-center">
+                    <div class="col-xs-12 col-sm-6">
+                      <p>
                         Explanation text
                       </p>
                     </div>
@@ -621,7 +621,7 @@
                 <t t-set="shift" t-value="shift_count_subscribed[0]" />
                 <t t-set="count" t-value="shift_count_subscribed[1]" />
                 <t t-set="is_subscribed" t-value="shift_count_subscribed[2]" />
-                <t t-set="highlight_class" t-value="'panel-danger' if count >= highlight_rule else 'panel-default'"/>
+                <t t-set="highlight_class" t-value="'panel-warning' if count >= highlight_rule else 'panel-default'"/>
                 <div t-att-class="'panel %s' % highlight_class">
                   <div class="panel-heading clearfix">
                     <div class="panel-title pull-left">
@@ -668,7 +668,7 @@
                     <t t-set="shift" t-value="shift_count_subscribed[0]" />
                     <t t-set="count" t-value="shift_count_subscribed[1]" />
                     <t t-set="is_subscribed" t-value="shift_count_subscribed[2]" />
-                    <tr t-attf-class="{{ 'danger' if count >= highlight_rule else '' }}">
+                    <tr t-attf-class="{{ 'warning' if count >= highlight_rule else '' }}">
                       <td>
                         <t t-esc="time.strftime('%A', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
                       </td>

--- a/beesdoo_website_shift/views/shift_website_templates.xml
+++ b/beesdoo_website_shift/views/shift_website_templates.xml
@@ -3,18 +3,22 @@
   <!-- Add menu entries -->
   <data noupdate="1">
     <record id="menu_work_irregular" model="website.menu">
-      <field name="name">Shifts Irregular</field>
-      <field name="url">/shift_irregular_worker</field>
+      <field name="name">Shifts</field>
+      <field name="url">/shift</field>
       <field name="parent_id" ref="website.main_menu"/>
       <field name="sequence" type="int">50</field>
     </record>
-    <record id="menu_work_regular" model="website.menu">
-      <field name="name">Shifts Regular</field>
-      <field name="url">/shift_template_regular_worker</field>
-      <field name="parent_id" ref="website.main_menu"/>
-      <field name="sequence" type="int">51</field>
-    </record>
   </data>
+
+  <!-- Shift -->
+  <template
+    id="shift"
+    name="Shift"
+    page="True">
+    <t t-call="website.layout">
+      <t t-esc="user.partner_id.working_mode"/>
+    </t>
+  </template>
 
   <!-- Available Tasks Templates for Regular Workers -->
   <template
@@ -141,10 +145,10 @@
     </t>
   </template>
 
-  <!-- Available shifts for irregular workers -->
+  <!-- Shifts for Irregular Workers -->
   <template
-    id="shift_template"
-    name="Available Shifts for Irregular Workers"
+    id="irregular_worker"
+    name="Shifts for Irregular Workers"
     page="True">
     <t t-call="website.layout">
 
@@ -155,7 +159,7 @@
           <div class="row">
             <div class="col-md-12">
               <h1 class="text-center">
-                Available Shifts for Irregular Workers
+                Your shifts
               </h1>
             </div>
           </div>
@@ -167,81 +171,296 @@
       <section class="wrap">
         <div class="container">
           <div class="row">
-            <div class="col-md-12">
-              <p class="text-center">
-                Subscribe via <a href="mailto:volant@bees-coop.be">volant@bees-coop.be</a>
+            <div class="col-xs-12 col-md-4 pull-right">
+
+              <section class="wrap">
+                <div class="container">
+                  <div class="row">
+                    <div class="col-md-12">
+                      <h2>
+                        Worker status
+                      </h2>
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <div class="oe_structure"/>
+
+              <p>
+                <label>Working Mode:</label>
+                <t t-esc="dict(status.fields_get(allfields=['working_mode'])['working_mode']['selection'])[status.working_mode]"/>
               </p>
+              <p>
+                <label>Status:</label>
+                <t t-esc="dict(status.fields_get(allfields=['status'])['status']['selection'])[status.status]"/>
+              </p>
+              <p>
+                <label>Absence Counter:</label>
+                <t t-esc="status.irregular_absence_counter"/>
+              </p>
+              <t t-if="status.holiday_start_time">
+                <p>
+                  <label>Holiday start time:</label>
+                  <t t-esc="status.holiday_start_time"/>
+                </p>
+                <p>
+                  <label>Holiday end time:</label>
+                  <t t-esc="status.holiday_end_time"/>
+                </p>
+              </t>
+              <p>
+                <label>Irregular start date:</label>
+                <t t-esc="status.irregular_start_date"/>
+              </p>
+              <p>
+                <label>Irregular absence date:</label>
+                <t t-if="status.irregular_absence_date">
+                  <t t-esc="status.irregular_absence_date"/>
+                </t>
+                <t t-if="not status.irregular_absence_date">
+                  No absence
+                </t>
+              </p>
+
+              <div class="oe_structure"/>
+
             </div>
-          </div>
-        </div>
-      </section>
 
-      <div class="oe_structure"/>
+            <div class="col-xs-12 col-md-8">
 
-      <section class="wrap">
-        <div class="container">
-          <div class="row">
+              <section class="wrap">
+                <div class="container">
+                  <div class="row">
+                    <div class="col-md-12">
+                      <h2>
+                        Your next shifts
+                      </h2>
+                    </div>
+                  </div>
+                </div>
+              </section>
 
-            <div class="visible-xs" t-foreach="shift_templates" t-as="shift_and_count">
-              <t t-set="count" t-value="shift_and_count[0]" />
-              <t t-set="shift" t-value="shift_and_count[1]" />
-              <ul class="list-group">
-                <li t-attf-class="{{ 'list-group-item list-group-item-danger' if count >= highlight_rule else 'list-group-item' }}">
-                  <t t-esc="time.strftime('%A %d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
-                  <span t-field="shift.start_time" t-field-options='{"format": "HH:mm"}'/> -
-                  <span t-field="shift.end_time" t-field-options='{"format": "HH:mm"}'/>
-                </li>
-                <li t-attf-class="{{ 'list-group-item list-group-item-danger' if count >= highlight_rule else 'list-group-item' }}">
-                  <t t-esc="shift.task_type_id.name"/>
-                  <span class="badge">
-                    <t t-esc="count"/> space(s)
-                  </span>
-                </li>
-              </ul>
-            </div>
+              <div class="oe_structure"/>
 
-            <table class="hidden-xs table table-striped">
-              <thead>
-                <tr>
-                  <th>Day</th>
-                  <th>Date</th>
-                  <th>Time</th>
-                  <th class="hidden-sm">Shift</th>
-                  <th>Type of Shift</th>
-                  <th class="text-center">Available Spaces</th>
-                </tr>
-              </thead>
-              <tbody>
-                <t t-foreach="shift_templates" t-as="shift_and_count">
-                  <t t-set="count" t-value="shift_and_count[0]" />
-                  <t t-set="shift" t-value="shift_and_count[1]" />
-                  <tr t-attf-class="{{ 'danger' if count >= highlight_rule else '' }}">
-                    <td>
-                      <t t-esc="time.strftime('%A', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
-                    </td>
-                    <td>
-                      <t t-esc="time.strftime('%d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
-                    </td>
-                    <td>
+              <div class="visible-xs" t-foreach="subscribed_shifts" t-as="shift">
+                <div class="panel panel-default">
+                  <div class="panel-heading clearfix">
+                    <div class="panel-title">
+                      <t t-esc="time.strftime('%A %d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
                       <span t-field="shift.start_time" t-field-options='{"format": "HH:mm"}'/> -
                       <span t-field="shift.end_time" t-field-options='{"format": "HH:mm"}'/>
-                    </td>
-                    <td class="hidden-sm">
-                      <t t-esc="shift.task_template_id.name"/>
-                    </td>
-                    <td>
-                      <t t-esc="shift.task_type_id.name"/>
-                    </td>
-                    <td class="text-center">
-                      <t t-esc="count"/>
-                    </td>
+                    </div>
+                  </div>
+                  <div class="panel-body">
+                    <t t-esc="shift.task_type_id.name"/>
+                  </div>
+                </div>
+              </div>
+
+              <table class="hidden-xs table table-striped">
+                <thead>
+                  <tr>
+                    <th>Day</th>
+                    <th>Date</th>
+                    <th>Time</th>
+                    <th>Type of Shift</th>
                   </tr>
-                </t>
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  <t t-foreach="subscribed_shifts" t-as="shift">
+                    <tr>
+                      <td>
+                        <t t-esc="time.strftime('%A', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
+                      </td>
+                      <td>
+                        <t t-esc="time.strftime('%d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
+                      </td>
+                      <td>
+                        <span t-field="shift.start_time" t-field-options='{"format": "HH:mm"}'/> -
+                        <span t-field="shift.end_time" t-field-options='{"format": "HH:mm"}'/>
+                      </td>
+                      <td>
+                        <t t-esc="shift.task_type_id.name"/>
+                      </td>
+                    </tr>
+                  </t>
+                </tbody>
+              </table>
+
+              <section class="wrap" t-if="not subscribed_shifts">
+                <div class="container">
+                  <div class="row">
+                    <div class="col-md-12">
+                      <div class="alert alert-warning">
+                        <strong>Warning !</strong> You have not yet signed up to a shift.
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <section class="wrap">
+                <div class="container">
+                  <div class="row">
+                    <div class="col-md-12">
+                      <h2>
+                        Available Shifts
+                      </h2>
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <div class="oe_structure"/>
+
+              <section class="wrap">
+                <div class="container">
+                  <div class="row">
+                    <div class="col-md-12">
+                      <p class="text-center">
+                        Explanation text
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <div class="oe_structure"/>
+
+              <div class="visible-xs" t-foreach="shift_templates" t-as="shift_count_subscribed">
+                <t t-set="shift" t-value="shift_count_subscribed[0]" />
+                <t t-set="count" t-value="shift_count_subscribed[1]" />
+                <t t-set="is_subscribed" t-value="shift_count_subscribed[2]" />
+                <t t-set="highlight_class" t-value="'panel-danger' if count >= highlight_rule else 'panel-default'"/>
+                <div t-att-class="'panel %s' % highlight_class">
+                  <div class="panel-heading clearfix">
+                    <div class="panel-title pull-left">
+                      <t t-esc="time.strftime('%A %d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
+                      <span t-field="shift.start_time" t-field-options='{"format": "HH:mm"}'/> -
+                      <span t-field="shift.end_time" t-field-options='{"format": "HH:mm"}'/>
+                    </div>
+                    <div class="label label-default pull-right">
+                      <t t-esc="count"/> space(s)
+                    </div>
+                  </div>
+                  <div class="panel-body clearfix">
+                    <t t-esc="shift.task_type_id.name"/>
+                    <t t-if="is_subscribed">
+                      <div class="label label-success pull-right">
+                        <span class="fa fa-check" aria-hidden="true"></span>
+                        Subscribed
+                      </div>
+                    </t>
+                    <t t-if="not is_subscribed">
+                      <button type="button" class="btn btn-default btn-sm pull-right" data-toggle="modal"
+                        t-att-data-target="'#subscribe-shift-%s' % shift.id">
+                        <span class="fa fa-user-plus" aria-hidden="true"></span>
+                        Subscribe
+                      </button>
+                    </t>
+                  </div>
+                </div>
+              </div>
+
+              <table class="hidden-xs table table-striped">
+                <thead>
+                  <tr>
+                    <th>Day</th>
+                    <th>Date</th>
+                    <th>Time</th>
+                    <th>Type of Shift</th>
+                    <th class="text-center">Available Spaces</th>
+                    <th class="text-center">Subscribed</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <t t-foreach="shift_templates" t-as="shift_count_subscribed">
+                    <t t-set="shift" t-value="shift_count_subscribed[0]" />
+                    <t t-set="count" t-value="shift_count_subscribed[1]" />
+                    <t t-set="is_subscribed" t-value="shift_count_subscribed[2]" />
+                    <tr t-attf-class="{{ 'danger' if count >= highlight_rule else '' }}">
+                      <td>
+                        <t t-esc="time.strftime('%A', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
+                      </td>
+                      <td>
+                        <t t-esc="time.strftime('%d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
+                      </td>
+                      <td>
+                        <span t-field="shift.start_time" t-field-options='{"format": "HH:mm"}'/> -
+                        <span t-field="shift.end_time" t-field-options='{"format": "HH:mm"}'/>
+                      </td>
+                      <td>
+                        <t t-esc="shift.task_type_id.name"/>
+                      </td>
+                      <td class="text-center">
+                        <t t-esc="count"/>
+                      </td>
+                      <td class="text-center">
+                        <t t-if="is_subscribed">
+                          <div class="label label-success">
+                            <span class="fa fa-check" aria-hidden="true"></span>
+                            Subscribed
+                          </div>
+                        </t>
+                        <t t-if="not is_subscribed">
+                          <button type="button" class="btn btn-default btn-sm" data-toggle="modal"
+                            t-att-data-target="'#subscribe-shift-%s' % shift.id">
+                            <span class="fa fa-user-plus" aria-hidden="true"></span>
+                            Subscribe
+                          </button>
+                        </t>
+                      </td>
+                    </tr>
+                  </t>
+                </tbody>
+              </table>
+
+              <!-- Subscribe check -->
+              <t t-foreach="shift_templates" t-as="shift_count_subscribed">
+                <t t-set="shift" t-value="shift_count_subscribed[0]" />
+                <t t-set="count" t-value="shift_count_subscribed[1]" />
+                <t t-set="is_subscribed" t-value="shift_count_subscribed[2]" />
+                <div class="modal fade" t-att-id="'subscribe-shift-%s' % shift.id" tabindex="-1" role="dialog"
+                     t-att-aria-labelledby="'subscribe-shift-%s-label' % shift.id">
+                  <div class="modal-dialog" role="document">
+                    <div class="modal-content">
+                      <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                          <span aria-hidden="true">×</span>
+                        </button>
+                        <h4 class="modal-title" t-att-id="'subscribe-shift-%s-label' % shift.id">
+                          Are you shure you want to subscribe to this shift?
+                        </h4>
+                      </div>
+                      <div class="modal-body">
+                        <t t-esc="time.strftime('%A', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
+                        <t t-esc="time.strftime('%d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
+                        <span t-field="shift.start_time" t-field-options='{"format": "HH:mm"}'/> -
+                        <span t-field="shift.end_time" t-field-options='{"format": "HH:mm"}'/><br/>
+                        <t t-esc="shift.task_type_id.name"/><br/>
+                        <t t-esc="count"/> available space(s)
+                      </div>
+                      <div class="modal-footer">
+                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                        <a class="btn btn-primary"
+                           t-att-href="'/shift/%s/subscribe?nexturl=%s' % (shift.id, nexturl)">
+                          Subscribe
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </t>
+
+              <div class="oe_structure"/>
+
+            </div> <!-- col-md-8 -->
           </div> <!-- row -->
         </div> <!-- container -->
       </section>
+
+      <div class="oe_structure"/>
 
     </t>
   </template>

--- a/beesdoo_website_shift/views/shift_website_templates.xml
+++ b/beesdoo_website_shift/views/shift_website_templates.xml
@@ -1,58 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright 2017-2018 Rémy Taymans <remytaymans@gmail.com>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
 <openerp>
 
   <!-- Add menu entries -->
   <data noupdate="1">
     <record id="menu_work_irregular" model="website.menu">
-      <field name="name">Shifts</field>
-      <field name="url">/shift</field>
+      <field name="name">Shifts Irregular</field>
+      <field name="url">/shift_irregular_worker</field>
       <field name="parent_id" ref="website.main_menu"/>
       <field name="sequence" type="int">50</field>
     </record>
+    <record id="menu_work_regular" model="website.menu">
+      <field name="name">Shifts Regular</field>
+      <field name="url">/shift_template_regular_worker</field>
+      <field name="parent_id" ref="website.main_menu"/>
+      <field name="sequence" type="int">51</field>
+    </record>
   </data>
 
-  <!-- Shift -->
+  <!-- Public Available Tasks Templates for Regular Workers -->
   <template
-    id="shift"
-    name="Shift"
-    page="True">
-    <t t-call="website.layout">
-
-      <section class="wrap">
-        <div class="container">
-          <div class="row">
-            <div class="col-md-12">
-              <h1 class="text-center">
-                Your shifts
-              </h1>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <div class="oe_structure"/>
-
-
-      <section class="wrap">
-        <div class="container">
-          <div class="row">
-            <div class="col-md-12">
-              <div class="alert alert-info">
-                You don't have to participate to shift system.
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <div class="oe_structure"/>
-
-    </t>
-  </template>
-
-  <!-- Shifts Exempted Workers -->
-  <template
-    id="exempted_worker"
-    name="Shifts for Exempted Workers"
+    id="public_shift_template_regular_worker"
+    name="Available Tasks Templates for Regular Workers"
     page="True">
     <t t-call="website.layout">
 
@@ -63,7 +35,7 @@
           <div class="row">
             <div class="col-md-12">
               <h1 class="text-center">
-                Your shifts
+                Available Tasks Templates for Regular Workers
               </h1>
             </div>
           </div>
@@ -75,267 +47,20 @@
       <section class="wrap">
         <div class="container">
           <div class="row">
-            <div class="col-xs-12 col-md-4 pull-right">
-
-              <section class="wrap">
-                <div class="container">
-                  <div class="row">
-                    <div class="col-md-12">
-                      <h2>
-                        Worker status
-                        <span t-att-class="'label %s pull-right' % ('label-success' if status.can_shop else 'label-danger',)">
-                          <span class="fa fa-shopping-cart"></span>
-                          <t t-if="status.can_shop">
-                            <span class="fa fa-check"></span>
-                          </t>
-                          <t t-if="not status.can_shop">
-                            <span class="fa fa-times"></span>
-                          </t>
-                        </span>
-                      </h2>
-                    </div>
-                  </div>
-                </div>
-              </section>
-
-              <div class="oe_structure"/>
-
-              <p>
-                <label>Working Mode:</label>
-                <t t-esc="dict(status.fields_get(allfields=['working_mode'])['working_mode']['selection'])[status.working_mode]"/>
-              </p>
-
-              <p>
-                <label>Status:</label>
-                <t t-esc="dict(status.fields_get(allfields=['status'])['status']['selection'])[status.status]"/>
-              </p>
-
-              <p t-if="status.exempt_reason_id">
-                <label>Exempt Reason:</label>
-                <t t-esc="status.exempt_reason_id.name"/>
-              </p>
-
-              <p t-if="status.holiday_start_time">
-                <label>Holiday start time:</label>
-                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(status.holiday_start_time, '%Y-%m-%d'))"/>
-              </p>
-
-              <p t-if="status.holiday_end_time">
-                <label>Holiday end time:</label>
-                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(status.holiday_end_time, '%Y-%m-%d'))"/>
-              </p>
-
-              <div class="oe_structure"/>
-
-            </div>
-
-            <div class="col-xs-12 col-md-8">
-
-              <section class="wrap">
-                <div class="container">
-                  <div class="row">
-                    <div class="col-md-12">
-                      <div class="alert alert-info">
-                        You don't have to participate to shift system.
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </section>
-
-              <div class="oe_structure"/>
-
-            </div> <!-- col-md-8 -->
-          </div> <!-- row -->
-        </div> <!-- container -->
-      </section>
-
-      <div class="oe_structure"/>
-
-    </t>
-  </template>
-
-  <!-- Shifts for Regular Workers -->
-  <template
-    id="regular_worker"
-    name="Shifts for Regular Workers"
-    page="True">
-    <t t-call="website.layout">
-
-      <div class="oe_structure"/>
-
-      <section class="wrap">
-        <div class="container">
-          <div class="row">
             <div class="col-md-12">
-              <h1 class="text-center">
-                Your shifts
-              </h1>
+              <p class="text-center">
+                Subscribe via the member office or via
+                <a href="mailto:membre@bees-coop.be">membre@bees-coop.be</a>
+              </p>
             </div>
           </div>
         </div>
       </section>
 
-      <div class="oe_structure"/>
-
       <section class="wrap">
         <div class="container">
           <div class="row">
-            <div class="col-xs-12 col-md-4 pull-right">
-
-              <section class="wrap">
-                <div class="container">
-                  <div class="row">
-                    <div class="col-md-12">
-                      <h2>
-                        Worker status
-                        <span t-att-class="'label %s pull-right' % ('label-success' if status.can_shop else 'label-danger',)">
-                          <span class="fa fa-shopping-cart"></span>
-                          <t t-if="status.can_shop">
-                            <span class="fa fa-check"></span>
-                          </t>
-                          <t t-if="not status.can_shop">
-                            <span class="fa fa-times"></span>
-                          </t>
-                        </span>
-                      </h2>
-                    </div>
-                  </div>
-                </div>
-              </section>
-
-              <div class="oe_structure"/>
-
-              <p>
-                <label>Working Mode:</label>
-                <t t-esc="dict(status.fields_get(allfields=['working_mode'])['working_mode']['selection'])[status.working_mode]"/>
-              </p>
-
-              <p>
-                <label>Status:</label>
-                <t t-esc="dict(status.fields_get(allfields=['status'])['status']['selection'])[status.status]"/>
-              </p>
-
-              <p t-if="status.sr != 0">
-                <label>Shift in Advance:</label>
-                <t t-esc="status.sr"/>
-              </p>
-
-              <p t-if="status.sc != 0">
-                <label>Compensation Shift:</label>
-                <t t-esc="status.sc"/>
-              </p>
-
-              <p t-if="status.holiday_start_time">
-                <label>Begining of Holiday:</label>
-                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(status.holiday_start_time, '%Y-%m-%d'))"/>
-              </p>
-
-              <p t-if="status.holiday_end_time">
-                <label>End of Holiday:</label>
-                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(status.holiday_end_time, '%Y-%m-%d'))"/>
-              </p>
-
-              <p t-if="status.alert_start_time">
-                <label>In Alert Since:</label>
-                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(status.alert_start_time, '%Y-%m-%d'))"/>
-              </p>
-
-              <p t-if="status.extension_start_time">
-                <label>In Extension Since:</label>
-                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(status.extension_start_time, '%Y-%m-%d'))"/>
-              </p>
-
-              <div class="oe_structure"/>
-
-            </div>
-
-            <div class="col-xs-12 col-md-8">
-
-              <section class="wrap">
-                <div class="container">
-                  <div class="row">
-                    <div class="col-md-12">
-                      <h2>
-                        Your next shifts
-                      </h2>
-                    </div>
-                  </div>
-                </div>
-              </section>
-
-              <div class="oe_structure"/>
-
-              <div class="visible-xs" t-foreach="subscribed_shifts" t-as="shift">
-                <div class="panel panel-default">
-                  <div class="panel-heading clearfix">
-                    <div class="panel-title">
-                      <t t-esc="time.strftime('%A %d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
-                      <span t-field="shift.start_time" t-field-options='{"format": "HH:mm"}'/> -
-                      <span t-field="shift.end_time" t-field-options='{"format": "HH:mm"}'/>
-                    </div>
-                  </div>
-                  <div class="panel-body">
-                    <t t-esc="shift.task_type_id.name"/>
-                  </div>
-                </div>
-              </div>
-
-              <table class="hidden-xs table table-striped">
-                <thead>
-                  <tr>
-                    <th>Day</th>
-                    <th>Date</th>
-                    <th>Time</th>
-                    <th>Type of Shift</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <t t-foreach="subscribed_shifts" t-as="shift">
-                    <tr>
-                      <td>
-                        <t t-esc="time.strftime('%A', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
-                      </td>
-                      <td>
-                        <t t-esc="time.strftime('%d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
-                      </td>
-                      <td>
-                        <span t-field="shift.start_time" t-field-options='{"format": "HH:mm"}'/> -
-                        <span t-field="shift.end_time" t-field-options='{"format": "HH:mm"}'/>
-                      </td>
-                      <td>
-                        <t t-esc="shift.task_type_id.name"/>
-                      </td>
-                    </tr>
-                  </t>
-                </tbody>
-              </table>
-
-              <section class="wrap">
-                <div class="container">
-                  <div class="row">
-                    <div class="col-md-12">
-                      <h2>
-                        Available Task Templates
-                      </h2>
-                    </div>
-                  </div>
-                </div>
-              </section>
-
-              <div class="oe_structure"/>
-
-              <section class="wrap">
-                <div class="container">
-                  <div class="row">
-                    <div class="col-xs-12 col-sm-6">
-                      <p>
-                        Explanation text
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </section>
+            <div class="col-md-12">
 
               <div class="oe_structure"/>
 
@@ -411,7 +136,7 @@
                 </tbody>
               </table>
 
-            </div> <!-- col-md-8 -->
+            </div> <!-- col-md -->
           </div> <!-- row -->
         </div> <!-- container -->
       </section>
@@ -421,10 +146,11 @@
     </t>
   </template>
 
-  <!-- Shifts for Irregular Workers -->
+
+  <!-- Public Available Shifts for Irregular Workers -->
   <template
-    id="irregular_worker"
-    name="Shifts for Irregular Workers"
+    id="public_shift_irregular_worker"
+    name="Available Shifts for Irregular Workers"
     page="True">
     <t t-call="website.layout">
 
@@ -435,7 +161,7 @@
           <div class="row">
             <div class="col-md-12">
               <h1 class="text-center">
-                Your shifts
+                Available Shifts for Irregular Workers
               </h1>
             </div>
           </div>
@@ -447,305 +173,25 @@
       <section class="wrap">
         <div class="container">
           <div class="row">
-            <div class="col-xs-12 col-md-4 pull-right">
-
-              <section class="wrap">
-                <div class="container">
-                  <div class="row">
-                    <div class="col-md-12">
-                      <h2>
-                        Worker status
-                        <span t-att-class="'label %s pull-right' % ('label-success' if status.can_shop else 'label-danger',)">
-                          <span class="fa fa-shopping-cart"></span>
-                          <t t-if="status.can_shop">
-                            <span class="fa fa-check"></span>
-                          </t>
-                          <t t-if="not status.can_shop">
-                            <span class="fa fa-times"></span>
-                          </t>
-                        </span>
-                      </h2>
-                    </div>
-                  </div>
-                </div>
-              </section>
-
-              <div class="oe_structure"/>
-
-              <p>
-                <label>Working Mode:</label>
-                <t t-esc="dict(status.fields_get(allfields=['working_mode'])['working_mode']['selection'])[status.working_mode]"/>
+            <div class="col-md-12">
+              <p class="text-center">
+                Subscribe via <a href="mailto:volant@bees-coop.be">volant@bees-coop.be</a>
               </p>
-
-              <p>
-                <label>Status:</label>
-                <t t-esc="dict(status.fields_get(allfields=['status'])['status']['selection'])[status.status]"/>
-              </p>
-
-              <p>
-                <label>Shift in Advance:</label>
-                <t t-esc="status.sr"/>
-              </p>
-
-              <p t-if="date_before_last_shift">
-                <label>Date Before Last Shift:</label>
-                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(date_before_last_shift, '%Y-%m-%d'))"/>
-              </p>
-
-              <p t-if="status.holiday_start_time">
-                <label>Begining of Holiday:</label>
-                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(status.holiday_start_time, '%Y-%m-%d'))"/>
-              </p>
-
-              <p t-if="status.holiday_end_time">
-                <label>End of Holiday:</label>
-                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(status.holiday_end_time, '%Y-%m-%d'))"/>
-              </p>
-
-              <p t-if="status.irregular_absence_date">
-                <label>Last Absence Date:</label>
-                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(status.irregular_absence_date, '%Y-%m-%d'))"/>
-              </p>
-
-              <p t-if="status.irregular_absence_counter">
-                <label>Number of Absence:</label>
-                <t t-esc="status.irregular_absence_counter"/>
-              </p>
-
-              <div class="oe_structure"/>
-
             </div>
+          </div>
+        </div>
+      </section>
 
-            <div class="col-xs-12 col-md-8">
+      <div class="oe_structure"/>
 
-              <section class="wrap">
-                <div class="container">
-                  <div class="row">
-                    <div class="col-md-12">
-                      <h2>
-                        Your next shifts
-                      </h2>
-                    </div>
-                  </div>
-                </div>
-              </section>
+      <section class="wrap">
+        <div class="container">
+          <div class="row">
+            <div class="col-md-12">
 
-              <div class="oe_structure"/>
+              <t t-call="beesdoo_website_shift.available_shift_irregular_worker"/>
 
-              <div class="visible-xs" t-foreach="subscribed_shifts" t-as="shift">
-                <div class="panel panel-default">
-                  <div class="panel-heading clearfix">
-                    <div class="panel-title">
-                      <t t-esc="time.strftime('%A %d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
-                      <span t-field="shift.start_time" t-field-options='{"format": "HH:mm"}'/> -
-                      <span t-field="shift.end_time" t-field-options='{"format": "HH:mm"}'/>
-                    </div>
-                  </div>
-                  <div class="panel-body">
-                    <t t-esc="shift.task_type_id.name"/>
-                  </div>
-                </div>
-              </div>
-
-              <table class="hidden-xs table table-striped" t-if="subscribed_shifts">
-                <thead>
-                  <tr>
-                    <th>Day</th>
-                    <th>Date</th>
-                    <th>Time</th>
-                    <th>Type of Shift</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <t t-foreach="subscribed_shifts" t-as="shift">
-                    <tr>
-                      <td>
-                        <t t-esc="time.strftime('%A', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
-                      </td>
-                      <td>
-                        <t t-esc="time.strftime('%d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
-                      </td>
-                      <td>
-                        <span t-field="shift.start_time" t-field-options='{"format": "HH:mm"}'/> -
-                        <span t-field="shift.end_time" t-field-options='{"format": "HH:mm"}'/>
-                      </td>
-                      <td>
-                        <t t-esc="shift.task_type_id.name"/>
-                      </td>
-                    </tr>
-                  </t>
-                </tbody>
-              </table>
-
-              <section class="wrap" t-if="not subscribed_shifts">
-                <div class="container">
-                  <div class="row">
-                    <div class="col-md-12">
-                      <div class="alert alert-warning">
-                        <strong>Warning !</strong> You have not yet signed up to a shift.
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </section>
-
-              <section class="wrap">
-                <div class="container">
-                  <div class="row">
-                    <div class="col-md-12">
-                      <h2>
-                        Available Shifts
-                      </h2>
-                    </div>
-                  </div>
-                </div>
-              </section>
-
-              <div class="oe_structure"/>
-
-              <section class="wrap">
-                <div class="container">
-                  <div class="row">
-                    <div class="col-xs-12 col-sm-6">
-                      <p>
-                        Explanation text
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </section>
-
-              <div class="oe_structure"/>
-
-              <div class="visible-xs" t-foreach="shift_templates" t-as="shift_count_subscribed">
-                <t t-set="shift" t-value="shift_count_subscribed[0]" />
-                <t t-set="count" t-value="shift_count_subscribed[1]" />
-                <t t-set="is_subscribed" t-value="shift_count_subscribed[2]" />
-                <t t-set="highlight_class" t-value="'panel-warning' if count >= highlight_rule else 'panel-default'"/>
-                <div t-att-class="'panel %s' % highlight_class">
-                  <div class="panel-heading clearfix">
-                    <div class="panel-title pull-left">
-                      <t t-esc="time.strftime('%A %d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
-                      <span t-field="shift.start_time" t-field-options='{"format": "HH:mm"}'/> -
-                      <span t-field="shift.end_time" t-field-options='{"format": "HH:mm"}'/>
-                    </div>
-                    <div class="label label-default pull-right">
-                      <t t-esc="count"/> space(s)
-                    </div>
-                  </div>
-                  <div class="panel-body clearfix">
-                    <t t-esc="shift.task_type_id.name"/>
-                    <t t-if="is_subscribed">
-                      <div class="label label-success pull-right">
-                        <span class="fa fa-check" aria-hidden="true"></span>
-                        Subscribed
-                      </div>
-                    </t>
-                    <t t-if="irregular_enable_sign_up and not is_subscribed">
-                      <button type="button" class="btn btn-default btn-sm pull-right" data-toggle="modal"
-                        t-att-data-target="'#subscribe-shift-%s' % shift.id">
-                        <span class="fa fa-user-plus" aria-hidden="true"></span>
-                        Subscribe
-                      </button>
-                    </t>
-                  </div>
-                </div>
-              </div>
-
-              <table class="hidden-xs table table-striped">
-                <thead>
-                  <tr>
-                    <th>Day</th>
-                    <th>Date</th>
-                    <th>Time</th>
-                    <th>Type of Shift</th>
-                    <th class="text-center">Available Spaces</th>
-                    <th class="text-center" t-if="irregular_enable_sign_up">Subscribed</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <t t-foreach="shift_templates" t-as="shift_count_subscribed">
-                    <t t-set="shift" t-value="shift_count_subscribed[0]" />
-                    <t t-set="count" t-value="shift_count_subscribed[1]" />
-                    <t t-set="is_subscribed" t-value="shift_count_subscribed[2]" />
-                    <tr t-attf-class="{{ 'warning' if count >= highlight_rule else '' }}">
-                      <td>
-                        <t t-esc="time.strftime('%A', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
-                      </td>
-                      <td>
-                        <t t-esc="time.strftime('%d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
-                      </td>
-                      <td>
-                        <span t-field="shift.start_time" t-field-options='{"format": "HH:mm"}'/> -
-                        <span t-field="shift.end_time" t-field-options='{"format": "HH:mm"}'/>
-                      </td>
-                      <td>
-                        <t t-esc="shift.task_type_id.name"/>
-                      </td>
-                      <td class="text-center">
-                        <t t-esc="count"/>
-                      </td>
-                      <td class="text-center" t-if="irregular_enable_sign_up">
-                        <t t-if="is_subscribed">
-                          <div class="label label-success">
-                            <span class="fa fa-check" aria-hidden="true"></span>
-                            Subscribed
-                          </div>
-                        </t>
-                        <t t-if="not is_subscribed">
-                          <button type="button" class="btn btn-default btn-sm" data-toggle="modal"
-                            t-att-data-target="'#subscribe-shift-%s' % shift.id">
-                            <span class="fa fa-user-plus" aria-hidden="true"></span>
-                            Subscribe
-                          </button>
-                        </t>
-                      </td>
-                    </tr>
-                  </t>
-                </tbody>
-              </table>
-
-              <!-- Subscribe check -->
-              <t t-foreach="shift_templates" t-as="shift_count_subscribed">
-                <t t-set="shift" t-value="shift_count_subscribed[0]" />
-                <t t-set="count" t-value="shift_count_subscribed[1]" />
-                <t t-set="is_subscribed" t-value="shift_count_subscribed[2]" />
-                <div class="modal fade" t-att-id="'subscribe-shift-%s' % shift.id" tabindex="-1" role="dialog"
-                     t-att-aria-labelledby="'subscribe-shift-%s-label' % shift.id">
-                  <div class="modal-dialog" role="document">
-                    <div class="modal-content">
-                      <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                          <span aria-hidden="true">×</span>
-                        </button>
-                        <h4 class="modal-title" t-att-id="'subscribe-shift-%s-label' % shift.id">
-                          Are you shure you want to subscribe to this shift?
-                        </h4>
-                      </div>
-                      <div class="modal-body">
-                        <t t-esc="time.strftime('%A', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
-                        <t t-esc="time.strftime('%d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
-                        <span t-field="shift.start_time" t-field-options='{"format": "HH:mm"}'/> -
-                        <span t-field="shift.end_time" t-field-options='{"format": "HH:mm"}'/><br/>
-                        <t t-esc="shift.task_type_id.name"/><br/>
-                        <t t-esc="count"/> available space(s)
-                      </div>
-                      <div class="modal-footer">
-                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                        <a class="btn btn-primary"
-                           t-if="irregular_enable_sign_up"
-                           t-att-href="'/shift/%s/subscribe?nexturl=%s' % (shift.id, nexturl)">
-                          Subscribe
-                        </a>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </t>
-
-              <div class="oe_structure"/>
-
-            </div> <!-- col-md-8 -->
+            </div> <!-- col-md -->
           </div> <!-- row -->
         </div> <!-- container -->
       </section>
@@ -754,4 +200,5 @@
 
     </t>
   </template>
+
 </openerp>

--- a/beesdoo_website_shift/views/shift_website_templates.xml
+++ b/beesdoo_website_shift/views/shift_website_templates.xml
@@ -49,10 +49,10 @@
     </t>
   </template>
 
-  <!-- Available Tasks Templates for Regular Workers -->
+  <!-- Shifts for Regular Workers -->
   <template
-    id="task_template"
-    name="Available Tasks Templates for Regular Workers"
+    id="regular_worker"
+    name="Shifts for Regular Workers"
     page="True">
     <t t-call="website.layout">
 
@@ -63,7 +63,7 @@
           <div class="row">
             <div class="col-md-12">
               <h1 class="text-center">
-                Available Tasks Templates for Regular Workers
+                Your shifts
               </h1>
             </div>
           </div>
@@ -75,101 +75,228 @@
       <section class="wrap">
         <div class="container">
           <div class="row">
-            <div class="col-md-12">
-              <p class="text-center">
-                Subscribe via the member office or via
-                <a href="mailto:membre@bees-coop.be">membre@bees-coop.be</a>
+            <div class="col-xs-12 col-md-4 pull-right">
+
+              <section class="wrap">
+                <div class="container">
+                  <div class="row">
+                    <div class="col-md-12">
+                      <h2>
+                        Worker status
+                      </h2>
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <div class="oe_structure"/>
+
+              <p>
+                <label>Working Mode:</label>
+                <t t-esc="dict(status.fields_get(allfields=['working_mode'])['working_mode']['selection'])[status.working_mode]"/>
               </p>
+              <p>
+                <label>Status:</label>
+                <t t-esc="dict(status.fields_get(allfields=['status'])['status']['selection'])[status.status]"/>
+              </p>
+              <p>
+                <label>Regular Shift Counter:</label>
+                <t t-esc="status.sr"/>
+              </p>
+              <p>
+                <label>Compensation Shift Counter:</label>
+                <t t-esc="status.sc"/>
+              </p>
+              <t t-if="status.holiday_start_time">
+                <p>
+                  <label>Holiday start time:</label>
+                  <t t-esc="status.holiday_start_time"/>
+                </p>
+                <p>
+                  <label>Holiday end time:</label>
+                  <t t-esc="status.holiday_end_time"/>
+                </p>
+              </t>
+              <p>
+                <label>Alert start date:</label>
+                <t t-esc="status.alert_start_time"/>
+              </p>
+              <p>
+                <label>Extension start date:</label>
+                <t t-esc="status.extension_start_time"/>
+              </p>
+
+              <div class="oe_structure"/>
+
             </div>
-          </div>
-        </div>
+
+            <div class="col-xs-12 col-md-8">
+
+              <section class="wrap">
+                <div class="container">
+                  <div class="row">
+                    <div class="col-md-12">
+                      <h2>
+                        Your next shifts
+                      </h2>
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <div class="oe_structure"/>
+
+              <div class="visible-xs" t-foreach="subscribed_shifts" t-as="shift">
+                <div class="panel panel-default">
+                  <div class="panel-heading clearfix">
+                    <div class="panel-title">
+                      <t t-esc="time.strftime('%A %d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
+                      <span t-field="shift.start_time" t-field-options='{"format": "HH:mm"}'/> -
+                      <span t-field="shift.end_time" t-field-options='{"format": "HH:mm"}'/>
+                    </div>
+                  </div>
+                  <div class="panel-body">
+                    <t t-esc="shift.task_type_id.name"/>
+                  </div>
+                </div>
+              </div>
+
+              <table class="hidden-xs table table-striped">
+                <thead>
+                  <tr>
+                    <th>Day</th>
+                    <th>Date</th>
+                    <th>Time</th>
+                    <th>Type of Shift</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <t t-foreach="subscribed_shifts" t-as="shift">
+                    <tr>
+                      <td>
+                        <t t-esc="time.strftime('%A', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
+                      </td>
+                      <td>
+                        <t t-esc="time.strftime('%d %B %Y', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
+                      </td>
+                      <td>
+                        <span t-field="shift.start_time" t-field-options='{"format": "HH:mm"}'/> -
+                        <span t-field="shift.end_time" t-field-options='{"format": "HH:mm"}'/>
+                      </td>
+                      <td>
+                        <t t-esc="shift.task_type_id.name"/>
+                      </td>
+                    </tr>
+                  </t>
+                </tbody>
+              </table>
+
+              <section class="wrap">
+                <div class="container">
+                  <div class="row">
+                    <div class="col-md-12">
+                      <h2>
+                        Available Task Templates
+                      </h2>
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <div class="oe_structure"/>
+
+              <section class="wrap">
+                <div class="container">
+                  <div class="row">
+                    <div class="col-md-12">
+                      <p class="text-center">
+                        Explanation text
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <div class="oe_structure"/>
+
+              <div class="visible-xs" t-foreach="task_templates" t-as="template">
+                <div t-att-class="'panel %s' % ('panel-warning' if not template.super_coop_id else 'panel-default',)">
+                  <div class="panel-heading clearfix">
+                    <div class="panel-title pull-left">
+                      <t t-esc="template.planning_id.name"/> :
+                      <t t-esc="template.day_nb_id.name"/>
+                      <t t-esc='float_to_time(template.start_time)' /> -
+                      <t t-esc='float_to_time(template.end_time)'/>
+                    </div>
+                    <div class="label label-default pull-right"
+                      t-if="template.remaining_worker > 0">
+                      <t t-esc="template.remaining_worker"/> space(s)
+                    </div>
+                    <div class="label label-default pull-right"
+                      t-if="template.remaining_worker == 0">
+                      full
+                    </div>
+                  </div>
+                  <div class="panel-body clearfix">
+                    <t t-esc="template.task_type_id.name"/>
+                    <div class="label label-warning pull-right"
+                      t-if="not template.super_coop_id">
+                      Need Super Co-operator
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <table class="hidden-xs table table-striped">
+                <thead>
+                  <tr>
+                    <th>Week</th>
+                    <th>Day</th>
+                    <th>Time</th>
+                    <th>Type of Task</th>
+                    <th>Super Co-operator</th>
+                    <th class="text-center">Available Spaces</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <t t-foreach="task_templates" t-as="template">
+                    <!-- Row with no super coop will be shown in color -->
+                    <tr t-attf-class="{{ 'warning' if not template.super_coop_id else '' }}">
+                      <td>
+                        <t t-esc="template.planning_id.name"/>
+                      </td>
+                      <td>
+                        <t t-esc="template.day_nb_id.name"/>
+                      </td>
+                      <td>
+                        <t t-esc='float_to_time(template.start_time)' /> -
+                        <t t-esc='float_to_time(template.end_time)'/>
+                      </td>
+                      <td>
+                        <t t-esc="template.task_type_id.name"/>
+                      </td>
+                      <td>
+                        <t t-if="template.super_coop_id">
+                          Yes
+                        </t>
+                        <t t-if="not template.super_coop_id">
+                          Not yet
+                        </t>
+                      </td>
+                      <td class="text-center">
+                        <t t-esc="template.remaining_worker"/>
+                      </td>
+                    </tr>
+                  </t>
+                </tbody>
+              </table>
+
+            </div> <!-- col-md-8 -->
+          </div> <!-- row -->
+        </div> <!-- container -->
       </section>
 
       <div class="oe_structure"/>
-
-      <section class="wrap">
-        <div class="container">
-          <div class="row">
-
-            <p class="visible-xs text-center">
-              <span class="label label-warning">NSC</span> : This flag tells you that the shift needs a Super Co-operator
-            </p>
-            <div class="visible-xs" t-foreach="task_templates" t-as="template">
-              <ul class="list-group">
-                <li class="list-group-item">
-                  <t t-esc="template.planning_id.name"/> :
-                  <t t-esc="template.day_nb_id.name"/>
-                  <t t-esc='float_to_time(template.start_time)' /> -
-                  <t t-esc='float_to_time(template.end_time)'/>
-                  <span class="label label-warning pull-right"
-                    t-if="not template.super_coop_id">
-                    NSC
-                  </span>
-                </li>
-                <li class="list-group-item">
-                  <t t-esc="template.task_type_id.name"/>
-                  <span class="badge"
-                    t-if="template.remaining_worker > 0">
-                    <t t-esc="template.remaining_worker"/> space(s)
-                  </span>
-                  <span class="badge"
-                    t-if="template.remaining_worker == 0">
-                    full
-                  </span>
-                </li>
-              </ul>
-            </div>
-
-            <table class="hidden-xs table table-striped">
-              <thead>
-                <tr>
-                  <th>Week</th>
-                  <th class="hidden-sm">Task Template</th>
-                  <th>Day</th>
-                  <th>Time</th>
-                  <th>Type of Task</th>
-                  <th>Super Co-operator</th>
-                  <th class="text-center">Available Spaces</th>
-                </tr>
-              </thead>
-              <tbody>
-                <t t-foreach="task_templates" t-as="template">
-                  <!-- Row with no super coop will be shown in color -->
-                  <tr t-attf-class="{{ 'warning' if not template.super_coop_id else '' }}">
-                    <td>
-                      <t t-esc="template.planning_id.name"/>
-                    </td>
-                    <td class="hidden-sm">
-                      <t t-esc="template.name"/>
-                    </td>
-                    <td>
-                      <t t-esc="template.day_nb_id.name"/>
-                    </td>
-                    <td>
-                      <t t-esc='float_to_time(template.start_time)' /> -
-                      <t t-esc='float_to_time(template.end_time)'/>
-                    </td>
-                    <td>
-                      <t t-esc="template.task_type_id.name"/>
-                    </td>
-                    <td>
-                      <t t-if="template.super_coop_id">
-                        Yes
-                      </t>
-                      <t t-if="not template.super_coop_id">
-                        Not yet
-                      </t>
-                    </td>
-                    <td class="text-center">
-                      <t t-esc="template.remaining_worker"/>
-                    </td>
-                  </tr>
-                </t>
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </section>
 
     </t>
   </template>

--- a/beesdoo_website_shift/views/shift_website_templates.xml
+++ b/beesdoo_website_shift/views/shift_website_templates.xml
@@ -49,7 +49,7 @@
     </t>
   </template>
 
-  <!-- Shifts Exempt Workers -->
+  <!-- Shifts Exempted Workers -->
   <template
     id="exempted_worker"
     name="Shifts for Exempted Workers"
@@ -104,24 +104,26 @@
                 <label>Working Mode:</label>
                 <t t-esc="dict(status.fields_get(allfields=['working_mode'])['working_mode']['selection'])[status.working_mode]"/>
               </p>
+
               <p>
                 <label>Status:</label>
                 <t t-esc="dict(status.fields_get(allfields=['status'])['status']['selection'])[status.status]"/>
               </p>
-              <p>
+
+              <p t-if="status.exempt_reason_id">
                 <label>Exempt Reason:</label>
                 <t t-esc="status.exempt_reason_id.name"/>
               </p>
-              <t t-if="status.holiday_start_time">
-                <p>
-                  <label>Holiday start time:</label>
-                  <t t-esc="status.holiday_start_time"/>
-                </p>
-                <p>
-                  <label>Holiday end time:</label>
-                  <t t-esc="status.holiday_end_time"/>
-                </p>
-              </t>
+
+              <p t-if="status.holiday_start_time">
+                <label>Holiday start time:</label>
+                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(status.holiday_start_time, '%Y-%m-%d'))"/>
+              </p>
+
+              <p t-if="status.holiday_end_time">
+                <label>Holiday end time:</label>
+                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(status.holiday_end_time, '%Y-%m-%d'))"/>
+              </p>
 
               <div class="oe_structure"/>
 
@@ -208,35 +210,40 @@
                 <label>Working Mode:</label>
                 <t t-esc="dict(status.fields_get(allfields=['working_mode'])['working_mode']['selection'])[status.working_mode]"/>
               </p>
+
               <p>
                 <label>Status:</label>
                 <t t-esc="dict(status.fields_get(allfields=['status'])['status']['selection'])[status.status]"/>
               </p>
-              <p>
-                <label>Regular Shift Counter:</label>
+
+              <p t-if="status.sr != 0">
+                <label>Shift in Advance:</label>
                 <t t-esc="status.sr"/>
               </p>
-              <p>
-                <label>Compensation Shift Counter:</label>
+
+              <p t-if="status.sc != 0">
+                <label>Compensation Shift:</label>
                 <t t-esc="status.sc"/>
               </p>
-              <t t-if="status.holiday_start_time">
-                <p>
-                  <label>Holiday start time:</label>
-                  <t t-esc="status.holiday_start_time"/>
-                </p>
-                <p>
-                  <label>Holiday end time:</label>
-                  <t t-esc="status.holiday_end_time"/>
-                </p>
-              </t>
-              <p>
-                <label>Alert start date:</label>
-                <t t-esc="status.alert_start_time"/>
+
+              <p t-if="status.holiday_start_time">
+                <label>Begining of Holiday:</label>
+                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(status.holiday_start_time, '%Y-%m-%d'))"/>
               </p>
-              <p>
-                <label>Extension start date:</label>
-                <t t-esc="status.extension_start_time"/>
+
+              <p t-if="status.holiday_end_time">
+                <label>End of Holiday:</label>
+                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(status.holiday_end_time, '%Y-%m-%d'))"/>
+              </p>
+
+              <p t-if="status.alert_start_time">
+                <label>In Alert Since:</label>
+                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(status.alert_start_time, '%Y-%m-%d'))"/>
+              </p>
+
+              <p t-if="status.extension_start_time">
+                <label>In Extension Since:</label>
+                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(status.extension_start_time, '%Y-%m-%d'))"/>
               </p>
 
               <div class="oe_structure"/>
@@ -469,36 +476,40 @@
                 <label>Working Mode:</label>
                 <t t-esc="dict(status.fields_get(allfields=['working_mode'])['working_mode']['selection'])[status.working_mode]"/>
               </p>
+
               <p>
                 <label>Status:</label>
                 <t t-esc="dict(status.fields_get(allfields=['status'])['status']['selection'])[status.status]"/>
               </p>
+
               <p>
-                <label>Absence Counter:</label>
+                <label>Shift in Advance:</label>
+                <t t-esc="status.sr"/>
+              </p>
+
+              <p t-if="date_before_last_shift">
+                <label>Date Before Last Shift:</label>
+                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(date_before_last_shift, '%Y-%m-%d'))"/>
+              </p>
+
+              <p t-if="status.holiday_start_time">
+                <label>Begining of Holiday:</label>
+                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(status.holiday_start_time, '%Y-%m-%d'))"/>
+              </p>
+
+              <p t-if="status.holiday_end_time">
+                <label>End of Holiday:</label>
+                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(status.holiday_end_time, '%Y-%m-%d'))"/>
+              </p>
+
+              <p t-if="status.irregular_absence_date">
+                <label>Last Absence Date:</label>
+                <t t-esc="time.strftime('%A %d %B %Y', time.strptime(status.irregular_absence_date, '%Y-%m-%d'))"/>
+              </p>
+
+              <p t-if="status.irregular_absence_counter">
+                <label>Number of Absence:</label>
                 <t t-esc="status.irregular_absence_counter"/>
-              </p>
-              <t t-if="status.holiday_start_time">
-                <p>
-                  <label>Holiday start time:</label>
-                  <t t-esc="status.holiday_start_time"/>
-                </p>
-                <p>
-                  <label>Holiday end time:</label>
-                  <t t-esc="status.holiday_end_time"/>
-                </p>
-              </t>
-              <p>
-                <label>Irregular start date:</label>
-                <t t-esc="status.irregular_start_date"/>
-              </p>
-              <p>
-                <label>Irregular absence date:</label>
-                <t t-if="status.irregular_absence_date">
-                  <t t-esc="status.irregular_absence_date"/>
-                </t>
-                <t t-if="not status.irregular_absence_date">
-                  No absence
-                </t>
               </p>
 
               <div class="oe_structure"/>

--- a/beesdoo_website_shift/views/shift_website_templates.xml
+++ b/beesdoo_website_shift/views/shift_website_templates.xml
@@ -16,7 +16,36 @@
     name="Shift"
     page="True">
     <t t-call="website.layout">
-      <t t-esc="user.partner_id.working_mode"/>
+
+      <section class="wrap">
+        <div class="container">
+          <div class="row">
+            <div class="col-md-12">
+              <h1 class="text-center">
+                Your shifts
+              </h1>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div class="oe_structure"/>
+
+
+      <section class="wrap">
+        <div class="container">
+          <div class="row">
+            <div class="col-md-12">
+              <div class="alert alert-info">
+                You don't have to participate to shift system.
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div class="oe_structure"/>
+
     </t>
   </template>
 

--- a/beesdoo_website_theme/__openerp__.py
+++ b/beesdoo_website_theme/__openerp__.py
@@ -14,6 +14,7 @@
     'license': "AGPL-3",
     'category': 'Themes',
     'version': '9.0.0.1',
+    'application': True,
 
     'depends': ['website'],
 

--- a/beesdoo_website_theme/static/src/less/beesdoo_website_design.less
+++ b/beesdoo_website_theme/static/src/less/beesdoo_website_design.less
@@ -35,9 +35,12 @@
 
 
 /* Defines variables */
-@colors: #FCC300, #BD0926, #12235A, #D0B565, #E7511E, #4B67AA, #5CBEC3, #1A171B;
+//       yellow , red    , blue   , beige  , orange ,turquoise, black
+@colors: #FCC300, #BD0926, #12235A, #D0B565, #E7511E, #5CBEC3, #1A171B;
 //@nbcolors: length(@colors); /* For less >= 1.6 */
-@nbcolors: 8; /* For less <=1.4 */
+@nbcolors: 7; /* For less <=1.4 */
+@colors-light: #fee799, #e49da8, #b7c2dd, #ece1c1, #f5b9a5, #bee5e7;
+@nbcolors-light: 6;
 
 
 /* Main */
@@ -174,4 +177,44 @@ h2
 {
     font-family: BebasNeue, sans;
     font-size: 25px;
+}
+
+.alert-info
+{
+    background-color: extract(@colors-light, 3);
+    border-color: extract(@colors-light, 3);
+    color: extract(@colors, 3);
+}
+
+.alert-warning
+{
+    background-color: extract(@colors-light, 1);
+    border-color: extract(@colors-light, 1);
+}
+
+.alert-danger
+{
+    background-color: extract(@colors-light, 2);
+    border-color: extract(@colors-light, 2);
+}
+
+.panel-warning
+{
+    background-color: extract(@colors-light, 1);
+}
+
+.table > thead > tr > td.warning,
+.table > tbody > tr > td.warning,
+.table > tfoot > tr > td.warning,
+.table > thead > tr > th.warning,
+.table > tbody > tr > th.warning,
+.table > tfoot > tr > th.warning,
+.table > thead > tr.warning > td,
+.table > tbody > tr.warning > td,
+.table > tfoot > tr.warning > td,
+.table > thead > tr.warning > th,
+.table > tbody > tr.warning > th,
+.table > tfoot > tr.warning > th
+{
+    background-color: extract(@colors-light, 1);
 }

--- a/beesdoo_website_theme/static/src/less/beesdoo_website_design.less
+++ b/beesdoo_website_theme/static/src/less/beesdoo_website_design.less
@@ -155,6 +155,7 @@ h1
     font-family: BebasNeue, sans;
     text-align: center;
     position: relative;
+    margin-top: 1em;
     margin-bottom: 1em;
 }
 
@@ -167,4 +168,10 @@ h1:after
     display: block;
     margin: 0 auto;
     margin-top: 0.5em;
+}
+
+h2
+{
+    font-family: BebasNeue, sans;
+    font-size: 25px;
 }


### PR DESCRIPTION
This PR adds a personal page for each user that shows usefull information about the work of the cooperator in the cooperative.
This allows irregular worker to subscribe to a shift via the website.

I have also refactored all the templates and the controller, could you tell me if it's better ? :)

I still have to add some little functionnalities, but that doesn't change a lot.

Thanks for your review. :)