### PR TITLE
add product consumption statistics in purchase > inventory

### DIFF
--- a/product_average_consumption/__init__.py
+++ b/product_average_consumption/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/product_average_consumption/models/__init__.py
+++ b/product_average_consumption/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product_template

--- a/product_average_consumption/models/product_template.py
+++ b/product_average_consumption/models/product_template.py
@@ -1,0 +1,73 @@
+# -*- encoding: utf-8 -*-
+from openerp import models, fields, api
+import datetime as dt
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    consumption_calculation_method = fields.Selection(
+        selection=[('sales_history', 'Sales History')],
+        string='Consumption Calculation Method',
+        default='sales_history',
+    )
+    calculation_range = fields.Integer(
+        'Calculation range (days)',
+        default=365,
+    )
+
+    average_consumption = fields.Float(
+        string='Average consumption',
+        compute='_compute_average_daily_consumption',
+        digits=(100, 2),
+    )
+    total_consumption = fields.Float(
+        string='Total consumption',
+        compute='_compute_total_consumption',
+        # store=True,
+    )
+
+    @api.multi
+    @api.depends('total_consumption')
+    def _compute_average_daily_consumption(self):
+        for template in self:
+            if template.calculation_range > 0:
+                avg = template.total_consumption / template.calculation_range
+            else:
+                avg = 0
+            template.average_consumption = avg
+
+        return True
+
+    @api.depends('calculation_range')
+    @api.multi
+    def _compute_total_consumption(self):
+        for template in self:
+            products = (
+                self.env['product.product']
+                    .search([('product_tmpl_id', '=', template.id)]))
+            products_id = products.mapped('id')
+
+            today = dt.date.today()
+            pol_date_limit = today - dt.timedelta(days=template.calculation_range)
+
+            order_lines = (
+                self.env['pos.order.line']
+                    .search([
+                        ('product_id', 'in', products_id),
+                        ('create_date', '>', fields.Datetime.to_string(pol_date_limit))
+                ])
+            )
+
+            if len(order_lines) > 0:
+                res = sum(order_lines.mapped('qty'))
+            else:
+                res = 0
+            template.total_consumption = res
+        return True
+
+    @api.multi
+    def _compute_stock_coverage(self):
+        for template in self:
+            template.stock_coverage = 7.1
+        return True

--- a/product_average_consumption/tests/__init__.py
+++ b/product_average_consumption/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_product_computations

--- a/product_average_consumption/tests/test_product_computations.py
+++ b/product_average_consumption/tests/test_product_computations.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+from openerp.tests.common import TransactionCase
+import datetime as dt
+
+_datetimes = map(
+    lambda d: d.strftime('%Y-%m-%d %H:%M:%S'),
+    (dt.datetime.now() - dt.timedelta(days=d) for d in range(0, 24, 2)))
+
+_quantities = [0.64, 6.45, 9.65, 1.76, 9.14, 3.99,
+               6.92, 2.25, 6.91, 1.44, 6.52, 1.44]
+
+
+class TestProductTemplate(TransactionCase):
+
+    def setUp(self, *args, **kwargs):
+        result = super(TestProductTemplate, self).setUp(*args, **kwargs)
+
+        # enrico_groups = [1, 2, 3, 4, 8, 9, 10, 11, 14, 18, 23,  # fixme
+        #                  24, 25, 27, 28, 32, 33, 34, 35, 36, 41,
+        #                  42, 43, 47, 48, 51, 52, 53, 54, 57, 59,
+        #                  60, 62, 63, 64, 65, 73, 75, 76, 77]
+        # # suspected_groups = [10, 35],
+        #
+        # user = self.env['res.users'].create({
+        #     'name': 'Test user product average consumption',
+        #     'login': 'testuserproductaverageconsumption',
+        #     'groups_id': [(6, 0, [enrico_groups])]
+        # })
+        # self.env = self.env(user=user)
+
+        test_product_template = (
+            self.env['product.template']
+                .create({'name': 'test product template',
+                         'calculation_range': 14,
+                         'consumption_calculation_method': 'sales_history',
+                         })
+        )
+
+        test_product = (
+            self.env['product.product']
+                .create({'name': 'test product',
+                         'product_tmpl_id': test_product_template.id
+                         })
+        )
+
+        for date, qty in zip(_datetimes, _quantities):
+            (self.env['pos.order.line']
+                 .create({'create_date': date,
+                          'qty': qty,
+                          'product_id': test_product.id
+                          })
+             )
+
+        self.test_product_template_id = test_product_template.id
+        return result
+
+    def test_create(self):
+        """Create a simple product template"""
+        Template = self.env['product.template']
+        product = Template.create({'name': 'Test product'})
+        self.assertEqual(product.name, 'Test product')
+
+    def test_compute_average_daily_consumption(self):
+        product_template = self.env['product.template'].browse(
+            self.test_product_template_id)
+        product_template.calculation_range = 14  # trigger compute
+        computed_value = product_template.average_consumption
+        expected_value = 4.08
+        self.assertEqual(computed_value, expected_value, 7)
+
+    def test_compute_total_consumption(self):
+        product_template = self.env['product.template'].browse(
+            self.test_product_template_id)
+        product_template.calculation_range = 14  # trigger compute
+        computed_value = product_template.total_consumption
+        expected_value = 57.11
+        self.assertEqual(computed_value, expected_value)

--- a/product_average_consumption/views/product_template_view.xml
+++ b/product_average_consumption/views/product_template_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<odoo>
+  <record id="beesdoo_product_form" model="ir.ui.view">
+      <field name="name">template.consumption.form</field>
+      <field name="model">product.template</field>
+      <field eval="7" name="priority"/>
+      <field name="inherit_id" ref="product.product_template_only_form_view"/>
+      <field name="arch" type="xml">
+      <group name="stock_property" position="after">
+        <group name="Consumption Figures">
+          <field name="consumption_calculation_method"/>
+          <field name="calculation_range" />
+          <field name="average_consumption"/>
+          <field name="total_consumption"/>
+        </group>
+      </group>
+    </field>
+  </record>
+</odoo>


### PR DESCRIPTION
⚠️~changes pushed by mistake on 9.0, real diff will appear after the fix~

cf https://github.com/coopiteasy/procurement-addons/pull/1

- add fields to purchase > inventory view (form)
- compute total consumption by article
- compute average based on consumption

Please review and comment. It seems to be working on my side but I am concerned about performance as odoo would perform 2 requests per product. I don't know how to use the orm
efficiently since I need to fetch calculation range for each product.

Another option is to use the following raw sql query:

```sql
select
  template.id as product_template_id,
  sum(pol.qty) as total_consumption
from pos_order_line pol
  join pos_order po ON pol.order_id = po.id
  join product_product product ON pol.product_id = product.id
  join product_template template ON product.product_tmpl_id = template.id
  where po.state = 'done'
    and product.active
    and pol.create_date
        BETWEEN date_trunc('day', now()) - calculation_range * interval '1 days'
            and date_trunc('day', now())
    and template.id in (1489, 4790, 1962)
group by product_template_id
```
and map the results on the current recordset. #