### PR TITLE
[ADD] pos_require_product_quantity

### DIFF
--- a/pos_require_product_quantity/__init__.py
+++ b/pos_require_product_quantity/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/pos_require_product_quantity/__openerp__.py
+++ b/pos_require_product_quantity/__openerp__.py
@@ -1,0 +1,26 @@
+# Copyright 2019 Coop IT Easy SCRLfs
+# 	    Robin Keunen <robin@coopiteasy.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Require Product Quantity in POS",
+    "version": "9.0.0.1.0",
+    "author": "Coop IT Easy SCRLfs",
+    "website": "www.coopiteasy.be",
+    "license": "AGPL-3",
+    "category": "Point of Sale",
+    "description": """
+        When adding a product to order line, this module sets the quantity to 
+          - 1 for "Unit" product,
+          - 0 for other product.
+        A popup is shown if product quantity is set to 0 when clicking on 
+        "Payment" button.  
+    """,
+    "depends": [
+        'point_of_sale',
+    ],
+    'data': [
+        'views/pos_config.xml',
+        'static/src/xml/templates.xml',
+    ],
+    'installable': True,
+}

--- a/pos_require_product_quantity/models/__init__.py
+++ b/pos_require_product_quantity/models/__init__.py
@@ -1,0 +1,1 @@
+from . import pos_config

--- a/pos_require_product_quantity/models/pos_config.py
+++ b/pos_require_product_quantity/models/pos_config.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# © 2016 Robin Keunen, Coop IT Easy SCRL fs
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+from openerp import models, fields, api
+
+
+class pos_config(models.Model):
+    _inherit = 'pos.config'
+
+    require_product_quantity = fields.Boolean(
+        string='Require product quantity in POS',
+        default=False,
+    )

--- a/pos_require_product_quantity/static/src/js/pos.js
+++ b/pos_require_product_quantity/static/src/js/pos.js
@@ -1,0 +1,71 @@
+/*
+  Copyright 2019 Coop IT Easy SCRLfs
+  	    Robin Keunen <robin@coopiteasy.be>
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+*/
+
+odoo.define(
+
+'pos_require_product_quantity.pos_require_product_quantity',
+function (require) {
+"use strict";
+
+var core = require('web.core');
+var models = require('point_of_sale.models');
+var screens = require("point_of_sale.screens");
+
+var _t = core._t;
+var orderline_prototype = models.Orderline.prototype;
+
+models.Orderline = models.Orderline.extend({
+    initialize: function (attr, options) {
+        orderline_prototype.initialize.call(this, attr, options);
+
+        var unit = this.get_unit();
+        if (unit) {
+            if (unit.category_id[1] === 'Unit') {
+                this.set_quantity(1);
+            } else {
+                this.set_quantity(0);
+            }
+        }
+    }
+});
+
+screens.ActionpadWidget = screens.ActionpadWidget.include({
+    renderElement: function () {
+        var self = this;
+        this._super();
+
+        this.$('.pay').click(function(){
+
+            if (self.pos.config.require_product_quantity) {
+
+                var orderlines = self.pos.get_order().orderlines;
+                var qty_unset_list = [];
+
+                for(var i = 0; i < orderlines.length; i++) {
+                    var line = orderlines.models[i];
+                    if (line.quantity === 0) {
+                        qty_unset_list.push(line);
+                    }
+                }
+                if (qty_unset_list.length > 0) {
+                    self.gui.back();
+                    var body = _t('No quantity set for products:');
+                    for (var i = 0; i < qty_unset_list.length; i++) {
+                        body = body + '  - ' + qty_unset_list[i].product.display_name;
+                    }
+                    self.gui.show_popup(
+                        'alert',
+                        {
+                            'title': _t('Missing quantities'),
+                            'body': body,
+                        });
+                }
+            }
+        });
+    }
+})
+
+});

--- a/pos_require_product_quantity/static/src/xml/templates.xml
+++ b/pos_require_product_quantity/static/src/xml/templates.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <template id="assets_backend" name="pos_require_product_quantity_extension_assets" inherit_id="web.assets_backend">
+          <xpath expr="." position="inside">
+              <script type="text/javascript"
+                      src="/pos_require_product_quantity/static/src/js/pos.js">
+              </script>
+          </xpath>
+        </template>
+    </data>
+</odoo>

--- a/pos_require_product_quantity/views/pos_config.xml
+++ b/pos_require_product_quantity/views/pos_config.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<odoo>
+
+    <record id="view_pos_config_form" model="ir.ui.view">
+        <field name="name">pos.config.form.view.inherit</field>
+        <field name="model">pos.config</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_config_form"/>
+        <field name="arch" type="xml">
+            <field name="tip_product_id" position="after">
+                <field name="require_product_quantity"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
https://gestion.coopiteasy.be/web#id=1196&view_type=form&model=project.task&menu_id=338&action=479

- add require_product_quantity parameter
- sets default order line quantity depending on product category
- pops up when an order line has quantity set to 0
