### PR TITLE
[FIX] beesdoo_product: main supplier info returns single record

### DIFF
--- a/beesdoo_product/models/beesdoo_product.py
+++ b/beesdoo_product/models/beesdoo_product.py
@@ -51,7 +51,13 @@ class BeesdooProduct(models.Model):
                 product.scale_sale_unit = 'P'
     
     def _get_main_supplier_info(self):
-        return self.seller_ids.sorted(key=lambda seller: seller.date_start, reverse=True)
+        suppliers = self.seller_ids.sorted(
+            key=lambda seller: seller.date_start,
+            reverse=True)
+        if suppliers:
+            return suppliers[0]
+        else:
+            return suppliers
 
     @api.one
     def generate_barcode(self):


### PR DESCRIPTION
Function `_get_main_supplier_info` can return several records when it should return only one. It crashes the assignment of `product.template.main_supplierinfo`

```
  File "/home/odoo/beescoop/beesdoo_custom/models/beesdoo_product.py", line 27, in _compute_main_supplierinfo
    product.main_supplierinfo = supplierinfo
  File "/home/odoo/odoo/openerp/fields.py", line 847, in __set__
    value = self.convert_to_cache(value, record)
  File "/home/odoo/odoo/openerp/fields.py", line 1694, in convert_to_cache
    raise ValueError("Wrong value for %s: %r" % (self, value))
ValueError: Wrong value for product.template.main_supplierinfo: product.supplierinfo(278, 424)
```