### PR TITLE
 [IMP] No irregular worker for replacement

### DIFF
--- a/beesdoo_shift/views/task.xml
+++ b/beesdoo_shift/views/task.xml
@@ -99,7 +99,7 @@
                             <field name="task_type_id" />
                             <field name="super_coop_id" />
                             <field name="worker_id" />
-                            <field name="replaced_id" attrs="{'invisible': [('is_regular', '!=', True)]}"/>
+                            <field name="replaced_id" attrs="{'invisible': [('is_regular', '!=', True)]}" domain="[('is_regular', '=', True)]"/>
                             <field name="is_regular" attrs="{'invisible': [('working_mode', '=', 'irregular')]}"/>
                             <field name="working_mode" invisible="1" />
                         </group>

--- a/beesdoo_shift/views/task.xml
+++ b/beesdoo_shift/views/task.xml
@@ -99,7 +99,7 @@
                             <field name="task_type_id" />
                             <field name="super_coop_id" />
                             <field name="worker_id" />
-                            <field name="replaced_id" attrs="{'invisible': [('is_regular', '!=', True)]}" domain="[('is_regular', '=', True)]"/>
+                            <field name="replaced_id" attrs="{'invisible': [('is_regular', '!=', True)]}" domain="[('working_mode', '=', 'regular')]"/>
                             <field name="is_regular" attrs="{'invisible': [('working_mode', '=', 'irregular')]}"/>
                             <field name="working_mode" invisible="1" />
                         </group>


### PR DESCRIPTION
Dans la gestion des shifts, un coopérateur régulier ne peut être remplacé par un coopérateur "volant".
Ancienne PR https://github.com/coopiteasy/Obeesdoo/pull/3 que j'ai fermée.