### PR TITLE
[IMP] Cannot create worker on shift

### DIFF
--- a/beesdoo_shift/views/task.xml
+++ b/beesdoo_shift/views/task.xml
@@ -98,7 +98,7 @@
                             <field name="task_template_id" />
                             <field name="task_type_id" />
                             <field name="super_coop_id" />
-                            <field name="worker_id" />
+                            <field name="worker_id" options="{'create': false, 'create_edit': false}"/>
                             <field name="replaced_id" attrs="{'invisible': [('is_regular', '!=', True)]}"/>
                             <field name="is_regular" attrs="{'invisible': [('working_mode', '=', 'irregular')]}"/>
                             <field name="working_mode" invisible="1" />


### PR DESCRIPTION
Pas de possibilité de créer un coopérateur directement à partir du champs worker_id dans la fiche d'enregistrement d'un shift.

Ancienne PR https://github.com/coopiteasy/Obeesdoo/pull/5