### PR TITLE
 [IMP] Supercoop resigning

### DIFF
--- a/beesdoo_shift/models/cooperative_status.py
+++ b/beesdoo_shift/models/cooperative_status.py
@@ -221,7 +221,7 @@ class CooperativeStatus(models.Model):
             if self.working_mode != 'irregular': #Don't reset alert time for irregular
                 data['alert_start_time'] = False
             self.write(data)
-        if new_state == 'unsubscribed':
+        if new_state == 'unsubscribed' or new_state == 'resigning':
             self.cooperator_id.sudo().write({'subscribed_shift_ids' : [(5,0,0)]})
             #TODO: Add one day othertwise unsubscribed from the shift you were absent
             self.env['beesdoo.shift.shift'].sudo().unsubscribe_from_today([self.cooperator_id.id], today=self.today)

--- a/beesdoo_shift/models/task.py
+++ b/beesdoo_shift/models/task.py
@@ -82,14 +82,13 @@ class Task(models.Model):
         to_unsubscribe_replace = self.search([('replaced_id', 'in', worker_ids)] + date_domain)
         to_unsubscribe_replace.write({'worker_id': False, 'is_regular': False, 'replaced_id': False})
 
-        # If worker is Super cooperative, remove it from planning
-        super_coop_id = self.env['res.users'].search(
+        # If worker is Super cooperator, remove it from planning
+        super_coop_ids = self.env['res.users'].search(
             [('partner_id', 'in', worker_ids), ('super', '=', True)]).ids
 
-        if super_coop_id:
-            to_unsubscribe_super_coop = self.search([('super_coop_id', 'in',
-                                                      super_coop_id)] +
-                                                    date_domain)
+        if super_coop_ids:
+            to_unsubscribe_super_coop = self.search(
+                [('super_coop_id', 'in', super_coop_ids)] + date_domain)
             to_unsubscribe_super_coop.write({'super_coop_id': False,
                                              'is_regular': False})
 

--- a/beesdoo_shift/models/task.py
+++ b/beesdoo_shift/models/task.py
@@ -81,12 +81,17 @@ class Task(models.Model):
         to_unsubscribe_replace = self.search([('replaced_id', 'in', worker_ids)] + date_domain)
         to_unsubscribe_replace.write({'worker_id': False, 'is_regular': False, 'replaced_id': False})
 
-        # if self.super_coop_id.id:
-        #     to_unsubscribe_super_coop = self.search([('super_coop_id', 'in',
-        #                                               self.super_coop_id.id)]
-        #                                             + date_domain)
-        #     to_unsubscribe_super_coop.write({'super_coop_id': False,
-        #                                      'is_regular': False})
+        # If worker is Super cooperative, remove it
+        super_coop_id = self.env['res.users'].search(
+            [('partner_id', '=', worker_ids[0]), ('super', '=', True)]).id
+
+        if super_coop_id:
+            to_unsubscribe_super_coop = self.search([('super_coop_id', '=',
+                                                      super_coop_id),
+                                                     ('start_time', '>=',
+                                                      today)])
+            to_unsubscribe_super_coop.write({'super_coop_id': False,
+                                             'is_regular': False})
 
     @api.multi
     def write(self, vals):

--- a/beesdoo_shift/models/task.py
+++ b/beesdoo_shift/models/task.py
@@ -70,7 +70,8 @@ class Task(models.Model):
         today += ' 00:00:00'
         if end_date:
             end_date += ' 23:59:59'
-        date_domain = [('worker_id', 'in', worker_ids), ('start_time', '>=', today)]
+        # date_domain = [('worker_id', 'in', worker_ids), ('start_time', '>=', today)]
+        date_domain = [('start_time', '>=', today)]
         if end_date:
             date_domain.append(('end_time', '<=', end_date))
         to_unsubscribe = self.search([('worker_id', 'in', worker_ids)] + date_domain)
@@ -81,15 +82,14 @@ class Task(models.Model):
         to_unsubscribe_replace = self.search([('replaced_id', 'in', worker_ids)] + date_domain)
         to_unsubscribe_replace.write({'worker_id': False, 'is_regular': False, 'replaced_id': False})
 
-        # If worker is Super cooperative, remove it
+        # If worker is Super cooperative, remove it from planning
         super_coop_id = self.env['res.users'].search(
-            [('partner_id', '=', worker_ids[0]), ('super', '=', True)]).id
+            [('partner_id', 'in', worker_ids), ('super', '=', True)]).ids
 
         if super_coop_id:
-            to_unsubscribe_super_coop = self.search([('super_coop_id', '=',
-                                                      super_coop_id),
-                                                     ('start_time', '>=',
-                                                      today)])
+            to_unsubscribe_super_coop = self.search([('super_coop_id', 'in',
+                                                      super_coop_id)] +
+                                                    date_domain)
             to_unsubscribe_super_coop.write({'super_coop_id': False,
                                              'is_regular': False})
 

--- a/beesdoo_shift/models/task.py
+++ b/beesdoo_shift/models/task.py
@@ -82,7 +82,11 @@ class Task(models.Model):
         to_unsubscribe_replace.write({'worker_id': False, 'is_regular': False, 'replaced_id': False})
 
         # if self.super_coop_id.id:
-        #     to_unsubscribe_replace.write({'super_coop_id': False})
+        #     to_unsubscribe_super_coop = self.search([('super_coop_id', 'in',
+        #                                               self.super_coop_id.id)]
+        #                                             + date_domain)
+        #     to_unsubscribe_super_coop.write({'super_coop_id': False,
+        #                                      'is_regular': False})
 
     @api.multi
     def write(self, vals):

--- a/beesdoo_shift/models/task.py
+++ b/beesdoo_shift/models/task.py
@@ -81,6 +81,9 @@ class Task(models.Model):
         to_unsubscribe_replace = self.search([('replaced_id', 'in', worker_ids)] + date_domain)
         to_unsubscribe_replace.write({'worker_id': False, 'is_regular': False, 'replaced_id': False})
 
+        # if self.super_coop_id.id:
+        #     to_unsubscribe_replace.write({'super_coop_id': False})
+
     @api.multi
     def write(self, vals):
         """

--- a/beesdoo_shift/views/task.xml
+++ b/beesdoo_shift/views/task.xml
@@ -97,8 +97,8 @@
                         <group>
                             <field name="task_template_id" />
                             <field name="task_type_id" />
-                            <field name="super_coop_id" />
-                            <field name="worker_id" options="{'no_create': True, 'no_open': True}"/>
+                            <field name="super_coop_id" domain="[('cooperative_status_ids.status', 'not in', ('unsubscribed', 'resigning'))]"/>
+                            <field name="worker_id" options="{'no_create': True, 'no_open': True}" domain="[('cooperative_status_ids.status', 'not in', ('unsubscribed', 'resigning'))]"/>
                             <field name="replaced_id"
                                    options="{'no_create': True, 'no_open': True}"
                                    domain="[('working_mode', '=', 'regular')]"

--- a/beesdoo_shift/wizard/subscribe.py
+++ b/beesdoo_shift/wizard/subscribe.py
@@ -81,7 +81,7 @@ class Subscribe(models.TransientModel):
         data = {
             'unsubscribed': True,
             'cooperator_id': self.cooperator_id.id,
-            'resigning' : self.resigning,
+            'resigning': self.resigning,
         }
         if status_id:
             status_id.sudo().write(data)


### PR DESCRIPTION
Suppression des shifts (dans worker informations) et des shifts futurs pour les super coopérateurs.

Dans task.py je me suis permis de modifier cette ligne
date_domain = [('worker_id', 'in', worker_ids), ('start_time', '>=', today)]
Car j'avais l'impression que 'worker_id', 'in', worker_ids faisait double emploi/

et ici :
to_unsubscribe_super_coop.write({'super_coop_id': False,
'is_regular': False}) --> je l'ai indiqué comme pour faire dans le code des worker_id, est-ce pertinent ?