### PR TITLE
[IMP] Purchase search product bees

### DIFF
--- a/beesdoo_purchase/views/purchase_order.xml
+++ b/beesdoo_purchase/views/purchase_order.xml
@@ -9,7 +9,7 @@
                      <field name="create_uid"/>
                  </field>
                 <field name="product_id" position="attributes">
-                    <attribute name="domain">[('main_seller_id','=', parent.partner_id)]</attribute>
+                    <attribute name="domain">[('main_seller_id','=', parent.partner_id), ('purchase_ok', '=', True)]</attribute>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
Article ne peut être acheté si la case "Peut être acheté " n'est pas coché.
Cette version conserve le filtre sur les fournisseurs.