### PR TITLE
[IMP] beesdoo_website_shift new configuration rule in pc

### DIFF
--- a/beesdoo_website_shift/data/res_config_data.xml
+++ b/beesdoo_website_shift/data/res_config_data.xml
@@ -9,9 +9,9 @@
       <field name="key">beesdoo_website_shift.irregular_shift_limit</field>
       <field name="value">0</field>
     </record>
-    <record id="beesdoo_website_shift.highlight_rule" model="ir.config_parameter">
-      <field name="key">beesdoo_website_shift.highlight_rule</field>
-      <field name="value">3</field>
+    <record id="beesdoo_website_shift.highlight_rule_pc" model="ir.config_parameter">
+      <field name="key">beesdoo_website_shift.highlight_rule_pc</field>
+      <field name="value">30</field>
     </record>
     <record id="beesdoo_website_shift.hide_rule" model="ir.config_parameter">
       <field name="key">beesdoo_website_shift.hide_rule</field>

--- a/beesdoo_website_shift/i18n/fr_BE.po
+++ b/beesdoo_website_shift/i18n/fr_BE.po
@@ -462,7 +462,7 @@ msgstr "S'inscrire"
 #. module: beesdoo_website_shift
 #: model:ir.ui.view,arch_db:beesdoo_website_shift.public_shift_irregular_worker
 msgid "Subscribe via"
-msgstr "Nous avons spécialement besoin d'aide pour les shifts&amp;nbsp; pour lesquels il y a au moins 3 places disponibles. Inscriptions via"
+msgstr "Nous avons spécialement besoin d'aide pour les shifts surlignés en jaune. Inscriptions via"
 
 #. module: beesdoo_website_shift
 #: model:ir.ui.view,arch_db:beesdoo_website_shift.public_shift_template_regular_worker

--- a/beesdoo_website_shift/models/res_config.py
+++ b/beesdoo_website_shift/models/res_config.py
@@ -8,17 +8,20 @@ from openerp import fields, models, api
 
 PARAMS = [
     ('irregular_shift_limit', 'beesdoo_website_shift.irregular_shift_limit'),
-    ('highlight_rule', 'beesdoo_website_shift.highlight_rule'),
+    ('highlight_rule_pc', 'beesdoo_website_shift.highlight_rule_pc'),
     ('hide_rule', 'beesdoo_website_shift.hide_rule'),
-    ('irregular_enable_sign_up', 'beesdoo_website_shift.irregular_enable_sign_up'),
-    ('irregular_past_shift_limit', 'beesdoo_website_shift.irregular_past_shift_limit'),
-    ('regular_past_shift_limit', 'beesdoo_website_shift.regular_past_shift_limit'),
-    ('regular_next_shift_limit', 'beesdoo_website_shift.regular_next_shift_limit'),
+    ('irregular_enable_sign_up',
+     'beesdoo_website_shift.irregular_enable_sign_up'),
+    ('irregular_past_shift_limit',
+     'beesdoo_website_shift.irregular_past_shift_limit'),
+    ('regular_past_shift_limit'
+     , 'beesdoo_website_shift.regular_past_shift_limit'),
+    ('regular_next_shift_limit',
+     'beesdoo_website_shift.regular_next_shift_limit'),
 ]
 
 
 class WebsiteShiftConfigSettings(models.TransientModel):
-
     _name = 'beesdoo.website.shift.config.settings'
     _inherit = 'res.config.settings'
 
@@ -26,11 +29,13 @@ class WebsiteShiftConfigSettings(models.TransientModel):
     irregular_shift_limit = fields.Integer(
         help="Maximum shift that will be shown"
     )
-    highlight_rule = fields.Integer(
-        help="Treshold of available space in a shift that trigger the highlight of the shift"
+    highlight_rule_pc = fields.Integer(
+        help="Treshold (in %) of available space in a shift that trigger the "
+             "highlight of the shift"
     )
     hide_rule = fields.Integer(
-        help="Treshold ((available space)/(max space)) in percentage of available space under wich the shift is hidden"
+        help="Treshold ((available space)/(max space)) in percentage of "
+             "available space under wich the shift is hidden"
     )
     irregular_enable_sign_up = fields.Boolean(
         help="Enable shift sign up for irregular worker"
@@ -58,46 +63,59 @@ class WebsiteShiftConfigSettings(models.TransientModel):
     @api.multi
     def get_default_irregular_shift_limit(self):
         return {
-            'irregular_shift_limit': int(self.env['ir.config_parameter'].get_param(
-                'beesdoo_website_shift.irregular_shift_limit'))
+            'irregular_shift_limit': int(
+                self.env['ir.config_parameter']
+                .get_param("beesdoo_website_shift.irregular_shift_limit")
+            )
         }
 
     @api.multi
-    def get_default_highlight_rule(self):
+    def get_default_highlight_rule_pc(self):
         return {
-            'highlight_rule': int(self.env['ir.config_parameter'].get_param('beesdoo_website_shift.highlight_rule'))
+            'highlight_rule_pc': int(
+                self.env['ir.config_parameter']
+                .get_param("beesdoo_website_shift.highlight_rule_pc")
+            )
         }
 
     @api.multi
     def get_default_hide_rule(self):
         return {
-            'hide_rule': int(self.env['ir.config_parameter'].get_param('beesdoo_website_shift.hide_rule'))
+            'hide_rule': int(self.env['ir.config_parameter'].get_param(
+                'beesdoo_website_shift.hide_rule'))
         }
 
     @api.multi
     def get_default_irregular_shift_sign_up(self):
         return {
-            'irregular_enable_sign_up': literal_eval(self.env['ir.config_parameter'].get_param(
-                'beesdoo_website_shift.irregular_enable_sign_up'))
+            'irregular_enable_sign_up':
+                literal_eval(self.env['ir.config_parameter'].get_param(
+                    'beesdoo_website_shift.irregular_enable_sign_up'))
         }
 
     @api.multi
     def get_default_irregular_past_shift_limit(self):
         return {
-            'irregular_past_shift_limit': int(self.env['ir.config_parameter'].get_param(
-                'beesdoo_website_shift.irregular_past_shift_limit'))
+            'irregular_past_shift_limit': int(
+                self.env['ir.config_parameter']
+                .get_param("beesdoo_website_shift.irregular_past_shift_limit")
+            )
         }
 
     @api.multi
     def get_default_regular_past_shift_limit(self):
         return {
-            'regular_past_shift_limit': int(self.env['ir.config_parameter'].get_param(
-                'beesdoo_website_shift.regular_past_shift_limit'))
+            'regular_past_shift_limit': int(
+                self.env['ir.config_parameter']
+                .get_param('beesdoo_website_shift.regular_past_shift_limit')
+            )
         }
 
     @api.multi
     def get_default_regular_next_shift_limit(self):
         return {
-            'regular_next_shift_limit': int(self.env['ir.config_parameter'].get_param(
-                'beesdoo_website_shift.regular_next_shift_limit'))
+            'regular_next_shift_limit': int(
+                self.env['ir.config_parameter']
+                .get_param('beesdoo_website_shift.regular_next_shift_limit')
+            )
         }

--- a/beesdoo_website_shift/views/my_shift_website_templates.xml
+++ b/beesdoo_website_shift/views/my_shift_website_templates.xml
@@ -380,7 +380,8 @@
       <t t-set="shift" t-value="shift_count_subscribed[0]" />
       <t t-set="count" t-value="shift_count_subscribed[1]" />
       <t t-set="is_subscribed" t-value="shift_count_subscribed[2]" />
-      <t t-set="highlight_class" t-value="'panel-warning' if count >= highlight_rule else 'panel-default'"/>
+      <t t-set="has_enough_workers" t-value="shift_count_subscribed[3]" />
+      <t t-set="highlight_class" t-value="'panel-warning' if not has_enough_workers else 'panel-default'"/>
       <div t-att-class="'panel %s' % highlight_class">
         <div class="panel-heading clearfix">
           <div class="panel-title pull-left">
@@ -427,7 +428,8 @@
           <t t-set="shift" t-value="shift_count_subscribed[0]" />
           <t t-set="count" t-value="shift_count_subscribed[1]" />
           <t t-set="is_subscribed" t-value="shift_count_subscribed[2]" />
-          <tr t-attf-class="{{ 'warning' if count >= highlight_rule else '' }}">
+          <t t-set="has_enough_workers" t-value="shift_count_subscribed[3]"/>
+          <tr t-attf-class="{{ 'warning' if not has_enough_workers else '' }}">
             <td>
               <t t-esc="time.strftime('%A', time.strptime(shift.start_time, '%Y-%m-%d %H:%M:%S'))"/>
             </td>

--- a/beesdoo_website_shift/views/res_config_views.xml
+++ b/beesdoo_website_shift/views/res_config_views.xml
@@ -20,8 +20,8 @@
             <field name="irregular_shift_limit"/>
           </div>
           <div>
-            <label for="highlight_rule"/>
-            <field name="highlight_rule"/>
+            <label for="highlight_rule_pc"/>
+            <field name="highlight_rule_pc"/>
           </div>
           <div>
             <label for="hide_rule"/>


### PR DESCRIPTION
Higlights des shifts pour lesquels une valeur en pourcent n'est pas atteinte.
@remytms 
J'ajoute cette nouvelle valeur au même endroit que la règle "hide_rule", est-ce pertinent ?

```python
has_enough_workers = free_space <= (task_template.worker_nb
                                                * highlight_rule_pc) / 100
            if free_space >= task_template.worker_nb * hide_rule:
                shifts_count_subscribed.append(
                    [shift_list[0]
                        , free_space, is_subscribed, has_enough_workers])
```