### PR TITLE
[FIX] beesdoo_shift remove only next shifts in planning for unsubscri…

### DIFF
--- a/beesdoo_shift/models/cooperative_status.py
+++ b/beesdoo_shift/models/cooperative_status.py
@@ -218,13 +218,15 @@ class CooperativeStatus(models.Model):
             self.write({'alert_start_time': self.today, 'extension_start_time': False, 'time_extension': 0})
         if new_state == 'ok':
             data = {'extension_start_time': False, 'time_extension': 0}
-            if self.working_mode != 'irregular': #Don't reset alert time for irregular
+            if self.working_mode != 'irregular':  # Don't reset alert time for irregular
                 data['alert_start_time'] = False
             self.write(data)
         if new_state == 'unsubscribed' or new_state == 'resigning':
-            self.cooperator_id.sudo().write({'subscribed_shift_ids' : [(5,0,0)]})
-            #TODO: Add one day othertwise unsubscribed from the shift you were absent
-            self.env['beesdoo.shift.shift'].sudo().unsubscribe_from_today([self.cooperator_id.id], today=self.today)
+            self.cooperator_id.sudo().write(
+                {'subscribed_shift_ids': [(5, 0, 0)]})
+            # TODO: Add one day otherwise unsubscribed from the shift you were absent
+            self.env['beesdoo.shift.shift'].sudo().unsubscribe_from_today(
+                [self.cooperator_id.id], today=fields.Date.today())
 
     def _change_counter(self, data):
         self.sc += data.get('sc', 0)

--- a/beesdoo_shift/models/task.py
+++ b/beesdoo_shift/models/task.py
@@ -77,8 +77,8 @@ class Task(models.Model):
         to_unsubscribe = self.search([('worker_id', 'in', worker_ids)] + date_domain)
 
         to_unsubscribe.write({'worker_id': False, 'is_regular': False})
-        #What about replacement ?
-        #Remove worker, replaced_id and regular
+        # What about replacement ?
+        # Remove worker, replaced_id and regular
         to_unsubscribe_replace = self.search([('replaced_id', 'in', worker_ids)] + date_domain)
         to_unsubscribe_replace.write({'worker_id': False, 'is_regular': False, 'replaced_id': False})
 


### PR DESCRIPTION
Supprime les shifts futurs à partir de la date du jour lors du passage en "désinscription" ou en "resigning".
Auparavant le champs "today" provenait de la vue "cooperative_status" était repris à la place de la date du jour.