### PR TITLE
[ADD] beesdoo_shift: add compensation shift option in task

### DIFF
--- a/beesdoo_shift/models/task.py
+++ b/beesdoo_shift/models/task.py
@@ -39,10 +39,21 @@ class Task(models.Model):
     stage_id = fields.Many2one('beesdoo.shift.stage', required=True, track_visibility='onchange', default=lambda self: self.env.ref('beesdoo_shift.open'))
     super_coop_id = fields.Many2one('res.users', string="Super Cooperative", domain=[('partner_id.super', '=', True)], track_visibility='onchange')
     color = fields.Integer(related="stage_id.color", readonly=True)
-    is_regular = fields.Boolean(default=False)
+    is_regular = fields.Boolean(default=False, string="Regular shift")
+    is_compensation = fields.Boolean(default=False, string="Compensation shift")
     replaced_id = fields.Many2one('res.partner', track_visibility='onchange', domain=[('eater', '=', 'worker_eater')])
     revert_info = fields.Text(copy=False)
     working_mode = fields.Selection(related='worker_id.working_mode')
+
+    @api.onchange('is_regular')
+    def _onchange_shift_is_regular(self):
+        for task in self:
+            task.is_compensation = not task.is_regular
+
+    @api.onchange('is_compensation')
+    def _onchange_shift_is_compensation(self):
+        for task in self:
+            task.is_regular = not task.is_compensation
 
     def message_auto_subscribe(self, updated_fields, values=None):
         self._add_follower(values)

--- a/beesdoo_shift/views/task.xml
+++ b/beesdoo_shift/views/task.xml
@@ -102,9 +102,16 @@
                             <field name="replaced_id"
                                    options="{'no_create': True, 'no_open': True}"
                                    domain="[('working_mode', '=', 'regular')]"
-                                   attrs="{'invisible': [('is_regular', '!=', True)]}"/>
-                            <field name="is_regular" attrs="{'invisible': [('working_mode', '=', 'irregular')]}"/>
-                            <field name="working_mode" invisible="1" />
+                                   attrs="{'invisible': [('is_regular', '!=', True), ('is_compensation', '!=', True)]}"/>
+                            <group>
+                                <field name="is_regular"
+                                       attrs="{'invisible': [('working_mode', '=', 'irregular')], 'required':[('is_compensation', '=', False)]}">
+                                    Regular shift
+                                </field>
+                                <field name="is_compensation"
+                                       attrs="{'invisible': [('working_mode', '=', 'irregular')], 'required':[('is_regular', '=', False)]}"/>
+                                <field name="working_mode" invisible="1"/>
+                            </group>
                         </group>
                         <group>
                             <field name="start_time" />
@@ -179,7 +186,7 @@
                                     Super Coop:
                                     <field name="super_coop_id" />
                                 </div>
-                                <div t-if="record.is_regular.raw_value" >
+                                <div t-if="record.is_regular.raw_value">
                                     Regular Shift
                                 </div>
 


### PR DESCRIPTION
force l'utilisateur à choisir entre un shift régulier ou un shift de compensation à l'enregistrement d'un shift. 