### PR TITLE
[ADD] b_purchase: Supervisor for sale order

### DIFF
--- a/beesdoo_purchase/__init__.py
+++ b/beesdoo_purchase/__init__.py
@@ -1,1 +1,2 @@
 # -*- coding: utf-8 -*-
+from . import models

--- a/beesdoo_purchase/__openerp__.py
+++ b/beesdoo_purchase/__openerp__.py
@@ -9,24 +9,18 @@
         Long description of module's purpose
     """,
 
-    'author': "Beescoop - Cellule IT",
+    'author': "Beescoop - Cellule IT, "
+              "Coop IT Easy SCRLfs",
     'website': "https://github.com/beescoop/Obeesdoo",
 
-    # Categories can be used to filter modules in modules listing
-    # Check https://github.com/odoo/odoo/blob/master/openerp/addons/base/module/module_data.xml
-    # for the full list
     'category': 'Purchase',
-    'version': '0.1',
+    'version': '9.0.1.1.0',
 
-    # any module necessary for this one to work correctly
-    'depends': ['purchase','beesdoo_product'],
+    'depends': ['purchase', 'beesdoo_product'],
 
-    # always loaded
     'data': [
         'views/purchase_order.xml',
         'security/ir.model.access.csv',
         'report/report_purchaseorder.xml',
     ],
-    # only loaded in demonstration mode
-    'demo': [],
 }

--- a/beesdoo_purchase/migrations/9.0.1.1.0/post-migrate.py
+++ b/beesdoo_purchase/migrations/9.0.1.1.0/post-migrate.py
@@ -1,0 +1,12 @@
+# coding: utf-8
+
+
+def migrate(cr, version):
+    """Set the new supervisor_id field if this one is empty."""
+    cr.execute(
+        """
+        UPDATE purchase_order
+        SET supervisor_id = create_uid
+        WHERE supervisor_id IS NULL
+        """
+    )

--- a/beesdoo_purchase/models/__init__.py
+++ b/beesdoo_purchase/models/__init__.py
@@ -1,0 +1,2 @@
+# coding: utf-8
+from . import purchase

--- a/beesdoo_purchase/models/purchase.py
+++ b/beesdoo_purchase/models/purchase.py
@@ -1,0 +1,41 @@
+# coding: utf-8
+
+from openerp import api, fields, models
+
+
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
+
+    # create_uid must mirror the supervisor_id value.
+    # create_uid is a magic field that belongs to the ORM that is not
+    # editable via a form.
+    create_uid = fields.Many2one(
+        comodel_name='res.users',
+        compute='_compute_create_uid',
+    )
+    supervisor_id = fields.Many2one(
+        comodel_name='res.users',
+        string='Responsible',
+        required=True,
+        default=lambda self: self.env.user,
+    )
+
+    @api.depends('supervisor_id')
+    def _compute_create_uid(self):
+        for rec in self:
+            if rec.supervisor_id:
+                rec.create_uid = rec.supervisor_id
+
+    @api.multi
+    def write(self, vals):
+        if 'supervisor_id' in vals:
+            new_supervisor = vals['supervisor_id']
+            for rec in self:
+                rec.message_unsubscribe_users(
+                    user_ids=rec.supervisor_id.ids,
+                )
+                rec.message_subscribe_users(
+                    user_ids=[new_supervisor],
+                    subtype_ids=[],
+                )
+        return super(PurchaseOrder, self).write(vals)

--- a/beesdoo_purchase/views/purchase_order.xml
+++ b/beesdoo_purchase/views/purchase_order.xml
@@ -6,10 +6,32 @@
             <field name="inherit_id" ref="purchase.purchase_order_form" />
             <field name="arch" type="xml">
                 <field name="date_order" position="after">
-                     <field name="create_uid"/>
+                     <field name="supervisor_id"/>
                  </field>
                 <field name="product_id" position="attributes">
                     <attribute name="domain">[('main_seller_id','=', parent.partner_id), ('purchase_ok', '=', True)]</attribute>
+                </field>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="beesdoo_purchase_order_tree_view">
+            <field name="name">beesdoo.purchase.order.tree.view</field>
+            <field name="model">purchase.order</field>
+            <field name="inherit_id" ref="purchase.purchase_order_tree" />
+            <field name="arch" type="xml">
+                <field name="origin" position="after">
+                     <field name="supervisor_id"/>
+                 </field>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="beesdoo_purchase_order_search_view">
+            <field name="name">beesdoo.purchase.order.search.view</field>
+            <field name="model">purchase.order</field>
+            <field name="inherit_id" ref="purchase.view_purchase_order_filter"/>
+            <field name="arch" type="xml">
+                <field name="create_uid" position="after">
+                    <field name="supervisor_id"/>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
This adds a field `supervisor_id` that aims to replace the `create_uid`
field. To prevent regressions, the old `create_uid` field is set to be a
computed field that has the same value as `supervisor_id`. This allow to
ensure that other part of the program that refer to `create_uid` as the
responsible for a purchase order will get the value of `supervisor_id`.

This new version comes with a migration script that fill the new
`supervisor_id` with the value of `create_uid` if `supervisor_id` is not
set yet.

This trick is done because the `create_uid` field is a magic field that
belongs to the ORM. This field cannot be modified in a form.