### PR TITLE
[FIX] b_shift: Too late shift validation

### DIFF
--- a/beesdoo_shift/__openerp__.py
+++ b/beesdoo_shift/__openerp__.py
@@ -13,7 +13,7 @@
     'website': "https://github.com/beescoop/Obeesdoo",
 
     'category': 'Cooperative management',
-    'version': '0.1',
+    'version': '9.0.1.0.1',
 
     'depends': ['beesdoo_base'],
 

--- a/beesdoo_shift/models/task.py
+++ b/beesdoo_shift/models/task.py
@@ -203,8 +203,16 @@ class Task(models.Model):
 
         elif self.worker_id.working_mode == 'irregular':
             status = self.worker_id.cooperative_status_ids[0]
+            alert_start_time = fields.Date.from_string(
+                self.worker_id.cooperative_status_ids[0].alert_start_time
+            )
+            start_time = fields.Date.from_string(self.start_time)
+            sr = self.worker_id.cooperative_status_ids[0].sr
             if new_stage == DONE or new_stage == NECESSITY:
-                data['sr'] = 1
+                if start_time <= alert_start_time and sr >= -2:
+                    data['sr'] = 2
+                else:
+                    data['sr'] = 1
                 data['irregular_absence_date'] = False
                 data['irregular_absence_counter'] = 1 if status.irregular_absence_counter < 0 else 0
             if new_stage == ABSENT or new_stage == EXCUSED:


### PR DESCRIPTION
This commit brings fix a bug that occur when a worker do a shift before
her future_alert_date and the shift was marked as attended after the
future_alert_date. In such a case, the worker fell in alert state and
get a -2. This don't fix the fact that the worker fall in alert. But
brings correction when the shift is finally marked as attended.