### PR TITLE
[CHG] b_shift: Remove alert_start_time when not in alert status

### DIFF
--- a/beesdoo_shift/__openerp__.py
+++ b/beesdoo_shift/__openerp__.py
@@ -13,7 +13,7 @@
     'website': "https://github.com/beescoop/Obeesdoo",
 
     'category': 'Cooperative management',
-    'version': '9.0.1.0.2',
+    'version': '9.0.1.1.0',
 
     'depends': ['beesdoo_base'],
 

--- a/beesdoo_shift/models/cooperative_status.py
+++ b/beesdoo_shift/models/cooperative_status.py
@@ -218,8 +218,7 @@ class CooperativeStatus(models.Model):
             self.write({'alert_start_time': self.today, 'extension_start_time': False, 'time_extension': 0})
         if new_state == 'ok':
             data = {'extension_start_time': False, 'time_extension': 0}
-            if self.working_mode != 'irregular':  # Don't reset alert time for irregular
-                data['alert_start_time'] = False
+            data['alert_start_time'] = False
             self.write(data)
         if new_state == 'unsubscribed' or new_state == 'resigning':
             # Remove worker from task_templates
@@ -304,7 +303,6 @@ class CooperativeStatus(models.Model):
             if delta and delta % PERIOD == 0 and status not in journal.line_ids:
                 if status.sr > 0:
                     status.sr -= 1
-                    status.alert_start_time = False
                 elif status.alert_start_time:
                     status.sr -= 1
                 else:


### PR DESCRIPTION
Before this commit, the alert_start_time was not erased when a status
change from 'alert' to 'ok' for an irregular worker.

People find that unintuitive (despite this date was in the past when
you are in 'ok' status).

Now, this alert_start_time was erased when the status change from
'alert' to 'ok'.