### PR TITLE
[FIX] b_shift: Properly resigning worker

### DIFF
--- a/beesdoo_shift/__openerp__.py
+++ b/beesdoo_shift/__openerp__.py
@@ -13,7 +13,7 @@
     'website': "https://github.com/beescoop/Obeesdoo",
 
     'category': 'Cooperative management',
-    'version': '9.0.1.0.1',
+    'version': '9.0.1.0.2',
 
     'depends': ['beesdoo_base'],
 


### PR DESCRIPTION
This fix the case where a worker is unsubscribed from a shift where he
is supercooperator.

In the function unsubscribed_from_today, when removing the supercoop,
the field is_regular was also set to False. I seams that this is not
correct as this field is related to the worker_id not to the supercoop.

Also, I found other issues as when removing a worker_id the fields
is_regular and is_compensation was not reset.

This let me think about other cases where worker_id is emptied, the
is_regular and is_compensation would be never been reset if the
programmer doesn't think to reset it.

So I modified the constrains on these field in order to have these field
reset properly when worker_id is changed.