### PR TITLE
[ADD] b_easy_my_coop: Info Session in new cooperator form

### DIFF
--- a/beesdoo_easy_my_coop/__init__.py
+++ b/beesdoo_easy_my_coop/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 import models
+from . import wizards

--- a/beesdoo_easy_my_coop/__openerp__.py
+++ b/beesdoo_easy_my_coop/__openerp__.py
@@ -25,6 +25,8 @@
     'data': [
         'data/product_share.xml',
         'views/partner.xml',
+        'views/subscription_request.xml',
+        'views/subscription_templates.xml',
     ],
     'auto_install': True,
     # only loaded in demonstration mode

--- a/beesdoo_easy_my_coop/models/__init__.py
+++ b/beesdoo_easy_my_coop/models/__init__.py
@@ -1,1 +1,2 @@
 import res_partner
+from . import subscription_request

--- a/beesdoo_easy_my_coop/models/res_partner.py
+++ b/beesdoo_easy_my_coop/models/res_partner.py
@@ -6,6 +6,10 @@ class Partner(models.Model):
 
     cooperator_type = fields.Selection(selection='_get_share_type', compute='_compute_share_type', string='Cooperator Type', store=True)
     can_shop = fields.Boolean(compute='_can_shop', store=True)
+    info_session_confirmed = fields.Boolean(
+        string="Confirmed presence to info session",
+        default=False,
+    )
 
     @api.depends('cooperator_type', 'cooperative_status_ids', 'cooperative_status_ids.can_shop')
     def _can_shop(self):

--- a/beesdoo_easy_my_coop/models/subscription_request.py
+++ b/beesdoo_easy_my_coop/models/subscription_request.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Coop IT Easy SCRLfs
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import api, fields, models, _
+
+
+class SubscriptionRequest(models.Model):
+
+    _inherit = 'subscription.request'
+
+    info_session_confirmed = fields.Boolean(
+        string="Confirmed Info Session",
+        default=False,
+    )
+
+    def get_partner_vals(self):
+        partner_vals = super(SubscriptionRequest, self).get_partner_vals()
+        partner_vals['info_session_confirmed'] = self.info_session_confirmed
+        return partner_vals

--- a/beesdoo_easy_my_coop/views/subscription_request.xml
+++ b/beesdoo_easy_my_coop/views/subscription_request.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 Coop IT Easy SCRLfs
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record model="ir.ui.view" id="subscription_request_form_view">
+        <field name="name">subscription.request.form (in beesdoo_easy_my_coop)</field>
+        <field name="model">subscription.request</field>
+        <field name="inherit_id" ref="easy_my_coop.subscription_request_form"/>
+        <field name="arch" type="xml">
+            <field name="data_policy_approved" position="before">
+                <field name="info_session_confirmed"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/beesdoo_easy_my_coop/views/subscription_templates.xml
+++ b/beesdoo_easy_my_coop/views/subscription_templates.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 Coop IT Easy SCRLfs
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+  <template id="beesdoo_easy_my_coop.becomecooperator"
+            name="Become Cooperator (in beesdoo_easy_my_coop)"
+            inherit_id="easy_my_coop.becomecooperator">
+      <xpath expr="//input[@name='data_policy_approved']/../.." position="before">
+          <div t-attf-class="form-group" >
+              <label class="col-md-3 col-sm-4 control-label" for="info_session_confirmed">Info Session</label>
+              <div class="col-md-1 col-sm-2">
+                  <input type="checkbox"
+                    class="form-control"
+                    name="info_session_confirmed"
+                    required="True"
+                    t-attf-value="#{info_session_confirmed or ''}"/>
+              </div>
+              <div class="col-md-6 col-sm-6">
+                  <t t-call="beesdoo_easy_my_coop.info_session_confirmed_text"/>
+              </div>
+          </div>
+      </xpath>
+  </template>
+
+  <data noupdate="1">
+    <template id="beesdoo_easy_my_coop.info_session_confirmed_text"
+              name="Info Session Confirmed Text">
+        Check if you have already take part to an information session.
+    </template>
+  </data>
+
+</odoo>

--- a/beesdoo_easy_my_coop/wizards/__init__.py
+++ b/beesdoo_easy_my_coop/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import beesdoo_shift_subscribe

--- a/beesdoo_easy_my_coop/wizards/beesdoo_shift_subscribe.py
+++ b/beesdoo_easy_my_coop/wizards/beesdoo_shift_subscribe.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Coop IT Easy SCRLfs
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import api, fields, models, _
+
+
+class Subscribe(models.TransientModel):
+
+    _inherit = 'beesdoo.shift.subscribe'
+
+    def _get_info_session_followed(self):
+        """
+        Check if the user has checked the info_session_confirmed in the
+        form to become new cooperator.
+        """
+        followed = super(Subscribe, self)._get_info_session_followed()
+        if not followed:
+            return (self.env['res.partner']
+                    .browse(self._context.get('active_id'))
+                    .info_session_confirmed)
+        return followed
+
+    info_session = fields.Boolean(default=_get_info_session_followed)
+


### PR DESCRIPTION
This adds, in the new cooperator form in the website, a checkbox that
the user can check if he already has taken part to an information
session.

This information will be saved in the partner object and will be used to
automatically check the info_session field of the cooperator_status when
it will be created by the wizard.