### PR TITLE
[ADD] b_shift: Set configurable limit to unsubscribe regular worker

### DIFF
--- a/beesdoo_shift/__openerp__.py
+++ b/beesdoo_shift/__openerp__.py
@@ -13,7 +13,7 @@
     'website': "https://github.com/beescoop/Obeesdoo",
 
     'category': 'Cooperative management',
-    'version': '9.0.1.1.1',
+    'version': '9.0.1.2.0',
 
     'depends': ['beesdoo_base'],
 

--- a/beesdoo_shift/data/system_parameter.xml
+++ b/beesdoo_shift/data/system_parameter.xml
@@ -27,4 +27,8 @@
         <field name="key">irregular_counter_to_unsubscribe</field>
         <field name="value">-4</field>
     </record>
+    <record id="regular_counter_to_unsubscribe" model="ir.config_parameter">
+        <field name="key">regular_counter_to_unsubscribe</field>
+        <field name="value">-4</field>
+    </record>
 </odoo>

--- a/beesdoo_shift/models/cooperative_status.py
+++ b/beesdoo_shift/models/cooperative_status.py
@@ -212,10 +212,11 @@ class CooperativeStatus(models.Model):
 
     def _set_regular_status(self, grace_delay, alert_delay):
         self.ensure_one()
+        counter_unsubscribe = int(self.env['ir.config_parameter'].get_param('regular_counter_to_unsubscribe', -4))
         ok = self.sr >= 0 and self.sc >= 0
         grace_delay = grace_delay + self.time_extension
 
-        if self.sr < -1 or self.unsubscribed:
+        if (self.sr + self.sc) <= counter_unsubscribe or self.unsubscribed:
             self.status = 'unsubscribed'
             self.can_shop = False
         elif self.today >= self.temporary_exempt_start_date and self.today <= self.temporary_exempt_end_date:


### PR DESCRIPTION
This adds a configurable limit under which the regular worker is
unsubscribed. The regular worker is unsubscribed when the sum of his
shift counter and his compensation shift counter reach the configured
limit.