### PR TITLE
[IMP] beesdoo_inventory: add filter on add item to reciept

### DIFF
--- a/beesdoo_inventory/__openerp__.py
+++ b/beesdoo_inventory/__openerp__.py
@@ -17,7 +17,7 @@
     # Check https://github.com/odoo/odoo/blob/master/openerp/addons/base/module/module_data.xml
     # for the full list
     'category': 'Sales Management',
-    'version': '0.1',
+    'version': '9.0.1.0.0',
 
     # any module necessary for this one to work correctly
     'depends': ['delivery', 'beesdoo_base'],

--- a/beesdoo_inventory/views/stock.xml
+++ b/beesdoo_inventory/views/stock.xml
@@ -27,6 +27,9 @@
                  <button name="copy_qty" string="Copy Pack Quantity" states="partially_available,assigned" type="object" class="oe_highlight"
                          attrs="{'invisible': ['|', ('picking_type_code', '!=', 'incoming')]}"/>
             </button>
+            <xpath expr="//field[@name='product_id']" position="attributes">
+                <attribute name="domain">[('main_seller_id', '=', parent.partner_id)]</attribute>
+            </xpath>
 		</field>
 	</record>
 


### PR DESCRIPTION
Added a domain to filter proposed products on the reciept view.
Only products whose main seller are the reciept's partner are
proposed in the auto-complete/selection.

