### PR TITLE
[FIX] b_w_shift: Shift with no start and end time

### DIFF
--- a/beesdoo_website_shift/controllers/main.py
+++ b/beesdoo_website_shift/controllers/main.py
@@ -367,7 +367,9 @@ class WebsiteShiftController(http.Controller):
                     limit=1,
                 )
                 main_shift = request.env['beesdoo.shift.shift'].sudo().search(
-                    [('task_template_id', '=', task_template[0].id)],
+                    [('task_template_id', '=', task_template[0].id),
+                     ('start_time', '!=', False),
+                     ('end_time', '!=', False)],
                     order="start_time desc",
                     limit=1,
                 )


### PR DESCRIPTION
When the worker has subscribed to a shift template but not yet to a
shift, the shift used to generate her next shift is the first shift
found in the shift template (so this is a shift that is attached to
another worker from the same shift template).

Now the system pays attention to not use a shift that has no start time
or end time defined.