### PR TITLE
[IMP] b_emc: Info session confirmation in new coop form

### DIFF
--- a/beesdoo_easy_my_coop/__init__.py
+++ b/beesdoo_easy_my_coop/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 import models
 from . import wizards
+from . import controllers

--- a/beesdoo_easy_my_coop/__openerp__.py
+++ b/beesdoo_easy_my_coop/__openerp__.py
@@ -16,7 +16,7 @@
     # Check https://github.com/odoo/odoo/blob/master/openerp/addons/base/module/module_data.xml
     # for the full list
     'category': 'Cooperative management',
-    'version': '1.0',
+    'version': '9.0.1.1.0',
 
     # any module necessary for this one to work correctly
     'depends': ['beesdoo_base', 'beesdoo_shift', 'easy_my_coop', 'easy_my_coop_eater'],
@@ -25,6 +25,7 @@
     'data': [
         'data/product_share.xml',
         'views/partner.xml',
+        'views/res_company.xml',
         'views/subscription_request.xml',
         'views/subscription_templates.xml',
     ],

--- a/beesdoo_easy_my_coop/controllers/__init__.py
+++ b/beesdoo_easy_my_coop/controllers/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import main

--- a/beesdoo_easy_my_coop/controllers/main.py
+++ b/beesdoo_easy_my_coop/controllers/main.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from openerp import http
+from openerp.http import request
+
+from openerp.addons.easy_my_coop.controllers.main import WebsiteSubscription as Base
+
+class WebsiteSubscription(Base):
+
+    @http.route()
+    def display_become_cooperator_page(self, **kwargs):
+        response = (super(WebsiteSubscription, self)
+                    .display_become_cooperator_page(**kwargs))
+        cmp = request.env['res.company']._company_default_get()
+        response.qcontext.update({
+            'display_info_session': cmp.display_info_session_confirmation,
+            'info_session_required': cmp.info_session_confirmation_required,
+            'info_session_text': cmp.info_session_confirmation_text,
+        })
+        return response

--- a/beesdoo_easy_my_coop/models/__init__.py
+++ b/beesdoo_easy_my_coop/models/__init__.py
@@ -1,2 +1,3 @@
 import res_partner
 from . import subscription_request
+from . import res_company

--- a/beesdoo_easy_my_coop/models/res_company.py
+++ b/beesdoo_easy_my_coop/models/res_company.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Coop IT Easy SCRLfs
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import api, fields, models, _
+
+
+class ResCompany(models.Model):
+
+    _inherit = 'res.company'
+    display_info_session_confirmation = fields.Boolean(
+        help="Choose to display a info session checkbox on the cooperator"
+        " website form."
+    )
+    info_session_confirmation_required = fields.Boolean(
+        string="Is info session confirmation required?"
+    )
+    info_session_confirmation_text = fields.Html(
+        translate=True,
+        help="Text to display aside the checkbox to confirm"
+        " participation to an info session."
+    )
+
+    @api.onchange('info_session_confirmation_required')
+    def onchange_info_session_confirmatio_required(self):
+        if self.info_session_confirmation_required:
+            self.display_info_session_confirmation = True

--- a/beesdoo_easy_my_coop/models/subscription_request.py
+++ b/beesdoo_easy_my_coop/models/subscription_request.py
@@ -18,3 +18,10 @@ class SubscriptionRequest(models.Model):
         partner_vals = super(SubscriptionRequest, self).get_partner_vals()
         partner_vals['info_session_confirmed'] = self.info_session_confirmed
         return partner_vals
+
+    def get_required_field(self):
+        required_fields = super(SubscriptionRequest, self).get_required_fiels()
+        company = self.env['res.company']._company_default_get()
+        if company.info_session_confirmation_required:
+            required_fields.append('info_session_confirmed')
+        return required_fields

--- a/beesdoo_easy_my_coop/views/res_company.xml
+++ b/beesdoo_easy_my_coop/views/res_company.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 Coop IT Easy SCRLfs
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record model="ir.ui.view" id="res_company_form_view">
+        <field name="name">res.company.form (in beesdoo_easy_my_coop)</field>
+        <field name="model">res.company</field>
+        <field name="inherit_id" ref="easy_my_coop.view_company_inherit_form2"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='coop_grp']//field[@name='display_data_policy_approval']" position="before">
+                <field name="display_info_session_confirmation"/>
+                <field name="info_session_confirmation_required"/>
+                <field name="info_session_confirmation_text"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/beesdoo_easy_my_coop/views/subscription_templates.xml
+++ b/beesdoo_easy_my_coop/views/subscription_templates.xml
@@ -7,27 +7,22 @@
   <template id="beesdoo_easy_my_coop.becomecooperator"
             name="Become Cooperator (in beesdoo_easy_my_coop)"
             inherit_id="easy_my_coop.becomecooperator">
-      <xpath expr="//input[@name='data_policy_approved']/../.." position="before">
-          <div t-attf-class="form-group" >
+      <xpath expr="//div[@id='data_policy_approved']" position="before">
+          <div id="info_session_confirmed" t-if="display_info_session" t-attf-class="form-group" >
               <label class="col-md-3 col-sm-4 control-label" for="info_session_confirmed">Info Session</label>
-              <div class="col-md-1 col-sm-2">
-                  <input type="checkbox"
-                    class="form-control"
-                    name="info_session_confirmed"
-                    t-attf-value="#{info_session_confirmed or ''}"/>
-              </div>
-              <div class="col-md-6 col-sm-6">
-                  <t t-call="beesdoo_easy_my_coop.info_session_confirmed_text"/>
+              <div class="col-md-9 col-sm-8">
+                  <div class="checkbox">
+                      <label>
+                          <input type="checkbox"
+                                 name="info_session_confirmed"
+                                 t-att="{'required': 'required'} if info_session_required else {}"
+                                 t-attf-value="#{data_policy_approved or ''}"/>
+                          <t t-raw="info_session_text"/>
+                      </label>
+                  </div>
               </div>
           </div>
       </xpath>
   </template>
-
-  <data noupdate="1">
-    <template id="beesdoo_easy_my_coop.info_session_confirmed_text"
-              name="Info Session Confirmed Text">
-        Check if you have already take part to an information session.
-    </template>
-  </data>
 
 </odoo>


### PR DESCRIPTION
This lets user configure if the info session confirmation should be
shown and/or required in the new cooperator form.

This other PR https://github.com/coopiteasy/vertical-cooperative/pull/4 should be merged before this one.