### PR TITLE
[FIX] b_base: remove test in report pdf name

### DIFF
--- a/beesdoo_base/__openerp__.py
+++ b/beesdoo_base/__openerp__.py
@@ -3,7 +3,7 @@
     'name': "Beescoop Base Module",
 
     'summary': """
-		Module that customize the base module and contains some python tools
+    Module that customize the base module and contains some python tools
      """,
 
     'description': """
@@ -13,7 +13,7 @@
     'website': "https://github.com/beescoop/Obeesdoo",
 
     'category': 'Project Management',
-    'version': '0.1',
+    'version': '9.0.1.0.1',
 
     'depends': ['point_of_sale', 'purchase', 'report', 'portal', 'partner_firstname'],
 

--- a/beesdoo_base/controllers/report.py
+++ b/beesdoo_base/controllers/report.py
@@ -47,7 +47,7 @@ class ReportCustom(ReportController):
 
                 cr, uid = request.cr, request.uid
                 report = request.registry['report']._get_report_from_name(cr, uid, reportname)
-                filename = "%s-test.%s" % (report.name, "pdf")
+                filename = "%s.%s" % (report.name, "pdf")
                 if docids:
                     ids = [int(x) for x in docids.split(",")]
                     obj = request.env[report.model].browse(ids)


### PR DESCRIPTION
There was a 'test' that was wrongly added to the name of the PDF report.