### PR TITLE
[FIX] beesdoo_shift : bug occuring when trying to save a temporary exempt

### DIFF
--- a/beesdoo_shift/__openerp__.py
+++ b/beesdoo_shift/__openerp__.py
@@ -13,7 +13,7 @@
     'website': "https://github.com/beescoop/Obeesdoo",
 
     'category': 'Cooperative management',
-    'version': '9.0.1.2.0',
+    'version': '9.0.1.2.1',
 
     'depends': ['beesdoo_base'],
 

--- a/beesdoo_shift/migrations/9.0.1.2.1/post-migrate.py
+++ b/beesdoo_shift/migrations/9.0.1.2.1/post-migrate.py
@@ -1,0 +1,11 @@
+# coding: utf-8
+
+
+def migrate(cr, version):
+    """Fix bug occuring when trying to save a temporary exempt
+     (missing sequence in database). """
+    cr.execute(
+        """
+        CREATE SEQUENCE IF NOT EXISTS beesdoo_website_shift_config_settings_id_seq
+        """
+    )


### PR DESCRIPTION
Caused by a missing sequence in database, fixed with post-migrate file.