### PR TITLE
fix: ghost error message

### DIFF
--- a/beesdoo_shift/__openerp__.py
+++ b/beesdoo_shift/__openerp__.py
@@ -13,7 +13,7 @@
     'website': "https://github.com/beescoop/Obeesdoo",
 
     'category': 'Cooperative management',
-    'version': '9.0.1.2.3',
+    'version': '9.0.1.2.4',
 
     'depends': ['beesdoo_base'],
 

--- a/beesdoo_shift/wizard/subscribe.py
+++ b/beesdoo_shift/wizard/subscribe.py
@@ -48,7 +48,11 @@ class Subscribe(models.TransientModel):
         return
 
     def _get_nb_shifts(self):
-        return len(self.env['res.partner'].browse(self._context.get('active_id')).subscribed_shift_ids)
+        if len(self.env['res.partner'].browse(self._context.get('active_id')).subscribed_shift_ids) > 1:
+            return _("Current worker has more than one shift, "
+                     "subscribing him to a new shift will erase all previous shifts.")
+        else:
+            return ""
 
     def _get_super(self):
         return self.env['res.partner'].browse(self._context.get('active_id')).super
@@ -72,7 +76,7 @@ class Subscribe(models.TransientModel):
     )
     exempt_reason_id = fields.Many2one('cooperative.exempt.reason', 'Exempt Reason')
     shift_id = fields.Many2one('beesdoo.shift.template', default=_get_shift)
-    nb_shifts = fields.Integer(string='Number of shifts', default=_get_nb_shifts)
+    nb_shifts_warning = fields.Char(default=_get_nb_shifts, readonly=True)
     reset_counter = fields.Boolean(default=_get_reset_counter_default)
     reset_compensation_counter = fields.Boolean(default=False)
     unsubscribed = fields.Boolean(default=False, string="Are you sure to unsubscribe this cooperator")

--- a/beesdoo_shift/wizard/subscribe.xml
+++ b/beesdoo_shift/wizard/subscribe.xml
@@ -16,16 +16,13 @@
                     <field name="working_mode" />
                     <field name="exempt_reason_id" attrs="{'invisible':[('working_mode', '!=', 'exempt')]}"/>
                     <field name="shift_id" domain="[('remaining_worker', '>', 0)]" attrs="{'invisible': [('working_mode', '!=', 'regular')]}"/>
-                    <field name="nb_shifts" attrs="{'invisible': True}"/>
                     <field name="irregular_start_date" attrs="{'invisible': [('working_mode', '!=', 'irregular')]}" />
                     <field name="super" />
                     <field name="reset_counter" />
                     <field name="reset_compensation_counter" /> <!-- TODO access right -->
                 </group>
                 <footer>
-                    <div class="alert alert-danger" role="alert" attrs="{'invisible': [('nb_shifts', '&lt;', 2)]}">
-                      Current worker has more than one shift, subscribing him to a new shift will erase all previous shifts.
-                    </div>
+                    <field name="nb_shifts_warning" class="alert-danger"/>
                     <button type="object" name="subscribe"
                         string="Confirm" class="oe_highlight" attrs="{'invisible': [('unsubscribed', '=', True)]}" />
                     <button type="object" name="unsubscribe"


### PR DESCRIPTION
The error message was displayed because the invisible condition is only
triggered when all the fields have been rendered and the javascript is
evaluated.

There is nothing I can do about that. Instead what I did was remove the
css box around the text so that if no text is present nothing is shown.
Added the error message as a field so that it only appears when the
attrs are evaluated.

If I leave the alert class an empty box is shown instead of the full message.
If you pay attention, at the same time than the error message is shown, so are the buttons and the or in between. This is inherent to how odoo templates are displayed.