### PR TITLE
[9.0][ADD] b_pos : default customer barcode config

### DIFF
--- a/beesdoo_pos/__openerp__.py
+++ b/beesdoo_pos/__openerp__.py
@@ -27,9 +27,9 @@
         'security/ir.model.access.csv',
         'views/beesdoo_pos.xml',
         'data/email.xml',
+        'data/default_barcode_pattern.xml',
         'data/cron.xml',
     ],
     'qweb': ['static/src/xml/templates.xml'],
     # only loaded in demonstration mode
 }
-

--- a/beesdoo_pos/data/default_barcode_pattern.xml
+++ b/beesdoo_pos/data/default_barcode_pattern.xml
@@ -1,0 +1,7 @@
+<odoo>
+    <data>
+        <record id="point_of_sale.barcode_rule_client" model="barcode.rule">
+            <field name="encoding">ean13</field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Override default data so as to set encoding to EAN-13.