### PR TITLE
[FIX] b_product: Show same field on product.template and product.product

### DIFF
--- a/beesdoo_product/views/beesdoo_product.xml
+++ b/beesdoo_product/views/beesdoo_product.xml
@@ -1,82 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <record model="ir.ui.view" id="beesdoo_product_form">
-        <field name="name">bees.product.template.form</field>
+    <record model="ir.ui.view" id="beesdoo_product_template_only_form">
+        <field name="name">bees.product.template.only.form</field>
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_only_form_view" />
         <field name="arch" type="xml">
             <field name="barcode" position="after">
                 <button string="Generate Barcode" name="generate_barcode" type="object" colspan="2" attrs="{'invisible' : [('barcode','!=',False)]}" /> />
             </field>
-            <field name="list_price" position="after">
-                <field name="suggested_price" widget='monetary' options="{'currency_field': 'currency_id'}" />
-            </field>
+            <!-- Added in sale.product_template_form_view_invoice_policy -->
             <field name="invoice_policy" position="attributes">
                 <attribute name="invisible">1</attribute>
             </field>
+            <!-- Added in purchase.view_product_supplier_inherit -->
             <field name="purchase_method" position="attributes">
                 <attribute name="invisible">1</attribute>
             </field>
+            <!-- Added in stock.view_template_property_form -->
             <field name="route_ids" position="attributes">
                 <attribute name="invisible">1</attribute>
             </field>
-            <group name="sale_condition" position="attributes">
-                <attribute name="invisible">1</attribute>
-            </group>
+            <!-- Added in purchase.product_template_form_view -->
             <field name="property_account_creditor_price_difference"
                 position="attributes">
                 <attribute name="invisible">1</attribute>
             </field>
-            <xpath expr="//group[@name='inventory']/.." position="after">
-                 <page string="Label">
-                     <group>
-                         <group name="label">
-                            <field name="total_with_vat"/>
-                            <field name="display_weight"/>
-                            <field name="display_unit"/>
-                            <field name="default_reference_unit"/>
-                            <field name="total_with_vat_by_unit" />
-                            <field name="total_deposit" />
-                         </group>
-                         <group>
-                            <field name="main_seller_id"/>
-                            <field name="eco_label"/>
-                            <field name="local_label"/>
-                            <field name="fair_label"/>
-                            <field name="origin_label"/>
-                            <field name="label_to_be_printed"/>
-                            <field name="label_last_printed"/>
-                         </group>
-                   </group>
-                   <group>
-                         <field name="note" />
-                 </group>
-                 </page>
-                 <page string="Scale labels" attrs="{'invisible':[('to_weight','=',False)]}">
-                 	<group>
-	                 	<group name="scale_label">
-	                 		<field name="deadline_for_sale"/>
-	                 		<field name="deadline_for_consumption"/>
-	                 		<field name="ingredients"/>
-	                 		<field name="scale_label_info_1"/>
-	                 		<field name="scale_label_info_2"/>
-	                 	</group>
-                 		<group>
-                 			<field name="scale_sale_unit"/>
-                 			<field name="scale_category" widget="selection"/>
-                 			<field name="scale_category_code"/>
-                 		</group>
-                 	</group>
-                 </page>
-             </xpath>
         </field>
     </record>
 
-    <record model="ir.ui.view" id="beesdoo_product_product_form">
-        <field name="name">bees.product.product.form</field>
-        <field name="model">product.product</field>
-        <field name="inherit_id" ref="product.product_normal_form_view" />
+    <record model="ir.ui.view" id="beesdoo_product_template_form">
+        <field name="name">bees.product.template.form</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view" />
         <field name="arch" type="xml">
+            <field name="list_price" position="after">
+                <field name="suggested_price" widget='monetary' options="{'currency_field': 'currency_id'}" />
+            </field>
+            <group name="sale_condition" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </group>
             <xpath expr="//group[@name='inventory']/.." position="after">
                 <page string="Label">
                     <group>
@@ -96,6 +58,25 @@
                             <field name="origin_label"/>
                             <field name="label_to_be_printed"/>
                             <field name="label_last_printed"/>
+                        </group>
+                    </group>
+                    <group>
+                        <field name="note" />
+                    </group>
+                </page>
+                <page string="Scale labels" attrs="{'invisible':[('to_weight','=',False)]}">
+                    <group>
+                        <group name="scale_label">
+                            <field name="deadline_for_sale"/>
+                            <field name="deadline_for_consumption"/>
+                            <field name="ingredients"/>
+                            <field name="scale_label_info_1"/>
+                            <field name="scale_label_info_2"/>
+                        </group>
+                        <group>
+                            <field name="scale_sale_unit"/>
+                            <field name="scale_category" widget="selection"/>
+                            <field name="scale_category_code"/>
                         </group>
                     </group>
                 </page>
@@ -172,7 +153,7 @@
 
     <menuitem id="label_configuration_menu" name="Labels" parent="product.prod_config_main"
               action="action_labels" sequence="20"/>
-              
+
     <record id="beesdoo_product_uom_categ_form" model="ir.ui.view">
         <field name="name">product.uom.categ.form</field>
         <field name="model">product.uom.categ</field>
@@ -194,7 +175,7 @@
           	</tree>
         </field>
     </record>
-        
+
     <record model="ir.ui.view" id="beesdoo_scale_category_form">
         <field name="name">beesdoo.scale.category.form</field>
         <field name="model">beesdoo.scale.category</field>
@@ -207,7 +188,7 @@
             </form>
         </field>
     </record>
-    
+
     <record model="ir.actions.act_window" id="action_scale_categories">
         <field name="name">Scale categories</field>
         <field name="res_model">beesdoo.scale.category</field>


### PR DESCRIPTION
Previously special fields for the product template where only added on
the product template form view only. But these fields should be available
also on the product product form view. So I moved fields that were easy to
move from template view only to the product template view that is used
for product template and product product.