### PR TITLE
[FIX] b_shift : automatic unsubscribe from next shifts 

### DIFF
--- a/beesdoo_shift/models/cooperative_status.py
+++ b/beesdoo_shift/models/cooperative_status.py
@@ -320,10 +320,10 @@ class CooperativeStatus(models.Model):
                 [('super_coop_id', 'in', self.cooperator_id.user_ids.ids)]
             )
             task_tpls.write({'super_coop_id': False})
-            # Remove worker for future task (remove also supercoop)
-            # TODO: Add one day otherwise unsubscribed from the shift you were absent
+            # Remove worker for future tasks (remove also supercoop)
             self.env['beesdoo.shift.shift'].sudo().unsubscribe_from_today(
-                [self.cooperator_id.id], today=fields.Date.today())
+                [self.cooperator_id.id], now=fields.Datetime.now()
+            )
 
     def _change_counter(self, data):
         self.sc += data.get('sc', 0)


### PR DESCRIPTION
When a worker is changing to _unsubscribed_ status. Doesn't unsubscribe him from present shift anymore, only from shifts starting right after unsubscription call.

Future shifts status cannot be modified anymore (only for _confirmed_ / _cancelled_). Thus we don't need to reset `revert_info` for unsubscribed shifts as it is never set.