### PR TITLE
[9.0][FIX] beesdoo_shift

### DIFF
--- a/beesdoo_shift/data/cron.xml
+++ b/beesdoo_shift/data/cron.xml
@@ -67,7 +67,7 @@
             <field name="numbercall">-1</field>
             <field name="doall" eval="False" />
             <field name="nextcall"
-                   eval="str(datetime.utcnow() + timedelta((6-datetime.utcnow().weekday()) % 7 ))"
+                   eval="(datetime.utcnow() + timedelta((6-datetime.utcnow().weekday()) % 7 )).strftime('%Y-%m-%d 21:00:00')"
             />
             <field name="model">beesdoo.shift.shift</field>
             <field name="function">_cron_send_weekly_emails</field>

--- a/beesdoo_shift/models/attendance_sheet.py
+++ b/beesdoo_shift/models/attendance_sheet.py
@@ -8,7 +8,16 @@ from openerp import _, api, exceptions, fields, models
 from openerp.exceptions import UserError, ValidationError
 
 
-class AttendanceSheetShift(models.AbstractModel):
+class AttendanceSheetShift(models.Model):
+    """
+    Partial copy of Task class to use in AttendanceSheet,
+    actual Task is updated at validation.
+
+    Should be Abstract and not used alone (common code for
+    AttendanceSheetShiftAdded and AttendanceSheetShiftExpected),
+    but create() method from res.partner raise error
+    when class is Abstract.
+    """
     _name = "beesdoo.shift.sheet.shift"
     _description = "Copy of an actual shift into an attendance sheet"
     _order = "task_type_id, worker_name"


### PR DESCRIPTION
Two fixes for `beesdoo_shift` :  

- next date computation for CRON was badly formatted.
- Odoo was doing SQL requests on abstract class `AttendanceSheetShift` on method `create()` call from `ResPartner`, so it has been swapped for a regular class.

I will apply same fixes to branch `12.0-mig-beesdoo_shift`.