### PR TITLE
[12.0][MIG][FIX] beesdoo_product

### DIFF
--- a/beesdoo_product/__manifest__.py
+++ b/beesdoo_product/__manifest__.py
@@ -27,6 +27,7 @@
         'data/barcode_rule.xml',
         'data/product_sequence.xml',
         'views/beesdoo_product.xml',
+        'views/assets.xml',
         'wizard/views/label_printing_utils.xml',
         'security/ir.model.access.csv',
     ],

--- a/beesdoo_product/models/beesdoo_product.py
+++ b/beesdoo_product/models/beesdoo_product.py
@@ -93,7 +93,7 @@ class BeesdooProduct(models.Model):
 
     @api.one
     @api.depends('taxes_id', 'list_price', 'taxes_id.amount',
-                 'taxes_id.tax_group_id', 'total_with_vat',
+                 'taxes_id.tax_group_id',
                  'display_weight', 'weight')
     def _get_total(self):
         consignes_group = self.env.ref('beesdoo_product.consignes_group_tax',

--- a/beesdoo_product/static/src/js/models.js
+++ b/beesdoo_product/static/src/js/models.js
@@ -1,0 +1,22 @@
+odoo.define('beesdoo_product.models', function (require) {
+    "use strict";
+
+    var models = require('point_of_sale.models');
+
+    var _super_PosModel = models.PosModel.prototype;
+
+    models.PosModel = models.PosModel.extend({
+
+        initialize: function (session, attributes) {
+
+            var product_model = _.find(this.models, function(model){
+                return model.model === 'product.product';
+            });
+            product_model.fields.push('total_with_vat');
+
+            // Inheritance
+            return _super_PosModel.initialize.call(this, session, attributes);
+        },
+
+    });
+});

--- a/beesdoo_product/views/assets.xml
+++ b/beesdoo_product/views/assets.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="assets_frontend" inherit_id="point_of_sale.assets">
+        <xpath expr="." position="inside">
+            <script type="text/javascript" src="/beesdoo_product/static/src/js/models.js"/>
+        </xpath>
+    </template>
+</odoo>

--- a/beesdoo_product/views/beesdoo_product.xml
+++ b/beesdoo_product/views/beesdoo_product.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="product.product_template_only_form_view" />
         <field name="arch" type="xml">
             <field name="barcode" position="after">
-                <button string="Generate Barcode" name="generate_barcode" type="object" colspan="2" attrs="{'invisible' : [('barcode','!=',False)]}" /> />
+                <button string="Generate Barcode" name="generate_barcode" type="object" colspan="2" attrs="{'invisible' : [('barcode','!=',False)]}" />
             </field>
             <field name="list_price" position="after">
                 <field name="suggested_price" widget='monetary' options="{'currency_field': 'currency_id'}" />


### PR DESCRIPTION
A double closing tag (`/> />`) caused a `child.attrs is undefined` error when clicking on a product:
![beesdoo_product_error](https://user-images.githubusercontent.com/28013700/78790375-b7043c80-79ae-11ea-8a5f-55363b4b7863.png)

Also, `total_with_vat` is removed from `@api.depends()` on the `_get_total` method: this field was depending on itself resulting in a warning when installing/updating the module.