### PR TITLE
[12.0][REM] beesdoo_product: pos_price_to_weight dependency

### DIFF
--- a/beesdoo_product/__manifest__.py
+++ b/beesdoo_product/__manifest__.py
@@ -20,7 +20,7 @@
     'website': "https://github.com/beescoop/Obeesdoo",
     'category': 'Sales',
     'version': '12.0.1.0.0',
-    'depends': ['beesdoo_base', 'product', 'sale', 'point_of_sale', 'pos_price_to_weight'],
+    'depends': ['beesdoo_base', 'product', 'sale', 'point_of_sale'],
 
     'data': [
         'data/product_label.xml',


### PR DESCRIPTION
`beesdoo_product` used to depend on `pos_price_to_weight` (for convenience, such that both were installed together), and the latter was a (cloned and modified) module located in this repository. We've switched to OCA's `pos_price_to_weight` now, but forgot to remove this dependency in https://github.com/beescoop/Obeesdoo/pull/148.