### PR TITLE
[12.0][FIX] b_shift, b_emc, macavrac_base: is_worker computed field

### DIFF
--- a/beesdoo_easy_my_coop/__manifest__.py
+++ b/beesdoo_easy_my_coop/__manifest__.py
@@ -26,7 +26,8 @@
         'views/res_company.xml',
         'views/subscription_request.xml',
         'views/subscription_templates.xml',
-        'views/product.xml'
+        'views/product.xml',
+        'views/res_partner.xml'
     ],
     'demo': [
         'demo/product_share.xml',

--- a/beesdoo_easy_my_coop/models/res_partner.py
+++ b/beesdoo_easy_my_coop/models/res_partner.py
@@ -12,12 +12,6 @@ class Partner(models.Model):
         string="Confirmed presence to info session",
         default=False,
     )
-    is_worker = fields.Boolean(
-        compute="_is_worker",
-        search="_search_worker",
-        readonly=True,
-        related=""
-    )
 
     def _cooperator_share_type(self):
         """
@@ -33,12 +27,9 @@ class Partner(models.Model):
         return share_type
 
     @api.depends(
-        'share_ids',
-        'share_ids.share_product_id',
-        'share_ids.share_product_id.default_code',
-        'share_ids.share_number',
+        "cooperator_type"
     )
-    def _is_worker(self):
+    def _compute_is_worker(self):
         """
         Return True if the partner can participate tho the shift system.
         This is defined on the share type.
@@ -47,13 +38,8 @@ class Partner(models.Model):
             share_type = rec._cooperator_share_type()
             if share_type:
                 rec.is_worker = share_type.allow_working
-                rec.worker_store = share_type.allow_working
             else:
                 rec.is_worker = False
-                rec.worker_store = False
-
-    def _search_worker(self, operator, value):
-        return [('worker_store', operator, value)]
 
     @api.depends(
         "cooperative_status_ids",

--- a/beesdoo_easy_my_coop/tests/test_res_partner.py
+++ b/beesdoo_easy_my_coop/tests/test_res_partner.py
@@ -143,7 +143,7 @@ class TestResPartner(TransactionCase):
             "beesdoo_base.res_partner_cooperator_1_demo"
         )
         # Run computed field
-        coop1._is_worker()
+        coop1._compute_is_worker()
         self.assertEqual(coop1.is_worker, True)
 
     def test_is_worker_share_b(self):
@@ -154,7 +154,7 @@ class TestResPartner(TransactionCase):
             "beesdoo_base.res_partner_cooperator_2_demo"
         )
         # Run computed field
-        coop2._is_worker()
+        coop2._compute_is_worker()
         self.assertEqual(coop2.is_worker, False)
 
     def test_search_worker(self):
@@ -169,8 +169,8 @@ class TestResPartner(TransactionCase):
             "beesdoo_base.res_partner_cooperator_2_demo"
         )
         # Run computed field
-        coop1._is_worker()
-        coop2._is_worker()
+        coop1._compute_is_worker()
+        coop2._compute_is_worker()
         workers = self.env["res.partner"].search([("is_worker", "=", True)])
         self.assertIn(coop1, workers)
         self.assertNotIn(coop2, workers)

--- a/beesdoo_easy_my_coop/views/res_partner.xml
+++ b/beesdoo_easy_my_coop/views/res_partner.xml
@@ -1,0 +1,16 @@
+<odoo>
+    <record model="ir.ui.view" id="super_coop_partner_inherited_view_form">
+        <field name="name">Partner Super Coop</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="beesdoo_shift.super_coop_partner_inherited_view_form"/>
+        <field name="priority">50</field>
+        <field name="arch" type="xml">
+            <field name="worker_store" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+            <field name="is_worker" position="attributes">
+                <attribute name="invisible">0</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/beesdoo_shift/models/res_partner.py
+++ b/beesdoo_shift/models/res_partner.py
@@ -13,7 +13,7 @@ class ResPartner(models.Model):
     _inherit = 'res.partner'
 
     worker_store = fields.Boolean(default=False)
-    is_worker = fields.Boolean(related="worker_store", string="Worker", readonly=False)
+    is_worker = fields.Boolean(string="Worker", compute="_compute_is_worker", store=True)
     can_shop = fields.Boolean(string="Is worker allowed to shop?", compute="_compute_can_shop", store=True)
     cooperative_status_ids = fields.One2many('cooperative.status', 'cooperator_id', readonly=True)
     super = fields.Boolean(related='cooperative_status_ids.super', string="Super Cooperative", readonly=True, store=True)
@@ -24,6 +24,11 @@ class ResPartner(models.Model):
     state = fields.Selection(related='cooperative_status_ids.status', readonly=True, store=True)
     extension_start_time = fields.Date(related='cooperative_status_ids.extension_start_time', string="Extension Start Day", readonly=True, store=True)
     subscribed_shift_ids = fields.Many2many('beesdoo.shift.template')
+
+    @api.depends("worker_store")
+    def _compute_is_worker(self):
+        for rec in self:
+            rec.is_worker = rec.worker_store
 
     @api.depends("cooperative_status_ids")
     def _compute_can_shop(self):

--- a/beesdoo_shift/views/cooperative_status.xml
+++ b/beesdoo_shift/views/cooperative_status.xml
@@ -37,7 +37,8 @@
                 </header>
             </xpath>
             <xpath expr="//field[@name='type']" position="before">
-                <field name="is_worker"/>
+                <field name="worker_store"/>
+                <field name="is_worker" invisible="1"/>
                 <field name="can_shop"/>
             </xpath>
             <xpath expr="//notebook" position="inside">

--- a/macavrac_base/models/res_partner.py
+++ b/macavrac_base/models/res_partner.py
@@ -28,7 +28,7 @@ class Partner(models.Model):
     comment_request = fields.Char(string="Commentaire")
 
     email_sent = fields.Boolean(string="Email envoyé")
-    is_worker = fields.Boolean(compute="_compute_is_worker", search="_search_is_worker", string="is Worker", readonly=True, related="")
+    is_worker = fields.Boolean(compute="_compute_is_worker", string="is Worker", readonly=True, store=True)
 
 
     @api.depends('share_qty')
@@ -41,9 +41,3 @@ class Partner(models.Model):
     def _compute_is_worker(self):
         for rec in self:
             rec.is_worker = rec.cooperator_type == 'share_b'
-
-    def _search_is_worker(self, operator, value):
-        if (operator == '=' and value) or (operator == '!=' and not value):
-            return [('cooperator_type', '=', 'share_b')]
-        else:
-            return [('cooperator_type', '!=', 'share_b')]


### PR DESCRIPTION
### [Task](https://gestion.coopiteasy.be/web#id=4706&view_type=form&model=project.task)

This PR brings changes on `res.partner` in the following modules:
- `beesdoo_shift`
- `beesdoo_easy_my_coop`
- `macavrac_base`

#### In `beesdoo_shift`:
- `is_worker`, initially `related`, is now `compute="_compute_is_worker"` (according to `worker_store` value) and `store=True` in order to not implement any `search=`. It his hidden in the view.
- `worker_store` is added to the view

#### In `beesdoo_easy_my_coop`:
- `_compute_is_worker()` overrides the parent behavior and `search="_search_worker"` is removed
- `worker_store` is hidden in the view
- `is_worker` is visible

#### In `macavrac_base`:
- `search="_search_is_worker"` is removed 

#### Context:
We had to implement those changes because, in `beesdoo_easy_my_coop`, `worker_store` remained `False` despite being assigned to the same value as `is_worker` in `_compute_is_worker()`. For a reason we couldn't explain, once the method was executed, the value was assigned back to `False`.

This was problematic since the `_search_worker()` was done on the `worker_store`. When a worker was subscribing to a shift, he was not appearing in it:
![beesdoo_easy_my_coop-error](https://user-images.githubusercontent.com/28013700/84391202-f04c6900-abf8-11ea-8d21-07b577795e29.png)
