### PR TITLE
[FIX] state draft doesn't exist anymore

### DIFF
--- a/beesdoo_website_shift/controllers/main.py
+++ b/beesdoo_website_shift/controllers/main.py
@@ -446,7 +446,7 @@ class WebsiteShiftController(http.Controller):
                 shift.planning_id = main_shift.planning_id
                 shift.task_type_id = main_shift.task_type_id
                 shift.worker_id = main_shift.worker_id
-                shift.state = "draft"
+                shift.state = "open"
                 shift.super_coop_id = main_shift.super_coop_id
                 shift.color = main_shift.color
                 shift.is_regular = main_shift.is_regular


### PR DESCRIPTION
Hello :) 
Le state "draft" n'existe plus sur beesdoo.shift.shift depuis le refacto du mois passé. 
Du coup, ça génère un traceback en ouvrant les shifts du coopérateur "My shifts" sur le site web. 
J'ai modifié my_shift_next_shifts pour mettre le state en open plutôt qu'en draft. A valider si c'est bien le comportement voulu. 
Merci.