### PR TITLE
[12.0][ADD] beesdoo_product: profit margin on suppliers

### DIFF
--- a/beesdoo_product/__manifest__.py
+++ b/beesdoo_product/__manifest__.py
@@ -2,6 +2,7 @@
 #   - Elouan Lebars <elouan@coopiteasy.be>
 #   - Rémy Taymans <remy@coopiteasy.be>
 #   - Houssine BAKKALI <houssine@coopiteasy.be>
+#   - Manuel Claeys Bouuaert <manuel@coopiteasy.be>
 #   - Elise Dupont
 #   - Thibault François
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
@@ -13,7 +14,7 @@
     "author": "Beescoop - Cellule IT, Coop IT Easy SCRLfs",
     "website": "https://github.com/beescoop/Obeesdoo",
     "category": "Sales",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.0.1",
     "depends": ["beesdoo_base", "product", "sale", "point_of_sale"],
     "data": [
         "data/product_label.xml",

--- a/beesdoo_product/__manifest__.py
+++ b/beesdoo_product/__manifest__.py
@@ -21,6 +21,7 @@
         "data/product_sequence.xml",
         "views/beesdoo_product.xml",
         "views/assets.xml",
+        "views/res_config_settings.xml",
         "wizard/views/label_printing_utils.xml",
         "security/ir.model.access.csv",
     ],

--- a/beesdoo_product/models/__init__.py
+++ b/beesdoo_product/models/__init__.py
@@ -1,1 +1,2 @@
 from . import beesdoo_product
+from . import res_conig_settings

--- a/beesdoo_product/models/__init__.py
+++ b/beesdoo_product/models/__init__.py
@@ -1,2 +1,2 @@
 from . import beesdoo_product
-from . import res_conig_settings
+from . import res_config_settings

--- a/beesdoo_product/models/beesdoo_product.py
+++ b/beesdoo_product/models/beesdoo_product.py
@@ -72,10 +72,8 @@ class BeesdooProduct(models.Model):
 
     note = fields.Text("Comments")
 
-    # S0023 : List_price = Price HTVA, so add a suggested price
-    list_price = fields.Float(string="exVAT Price")
     suggested_price = fields.Float(
-        string="Suggested exVAT Price", compute="_compute_cost", readOnly=True,
+        string="Suggested Price", compute="_compute_cost", readOnly=True,
         help="""
         This field computes a suggested price based on the 'Product Margin' 
         field on Partners (Vendors), if it's set, or otherwise on the 'Product 
@@ -332,7 +330,7 @@ class BeesdooProductCategory(models.Model):
 class BeesdooProductSupplierInfo(models.Model):
     _inherit = "product.supplierinfo"
 
-    price = fields.Float("exVAT Price")
+    price = fields.Float("Price")
 
 
 class BeesdooUOMCateg(models.Model):

--- a/beesdoo_product/models/beesdoo_product.py
+++ b/beesdoo_product/models/beesdoo_product.py
@@ -267,6 +267,11 @@ class BeesdooProduct(models.Model):
     @api.multi
     @api.depends("seller_ids", "supplier_taxes_id", "taxes_id")
     def _compute_cost(self):
+        suggested_price_reference = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("beesdoo_product.suggested_price_reference")
+        )
         for product in self:
             suppliers = product._get_main_supplier_info()
             if len(suppliers) > 0:
@@ -287,11 +292,6 @@ class BeesdooProduct(models.Model):
                 ].product_tmpl_id.categ_id.profit_margin
                 profit_margin = (
                     profit_margin_supplier or profit_margin_product_category
-                )
-                suggested_price_reference = (
-                    self.env["ir.config_parameter"]
-                    .sudo()
-                    .get_param("beesdoo_product.suggested_price_reference")
                 )
                 profit_margin_factor = (
                     1 / (1 - profit_margin / 100)

--- a/beesdoo_product/models/beesdoo_product.py
+++ b/beesdoo_product/models/beesdoo_product.py
@@ -75,7 +75,12 @@ class BeesdooProduct(models.Model):
     # S0023 : List_price = Price HTVA, so add a suggested price
     list_price = fields.Float(string="exVAT Price")
     suggested_price = fields.Float(
-        string="Suggested exVAT Price", compute="_compute_cost", readOnly=True
+        string="Suggested exVAT Price", compute="_compute_cost", readOnly=True,
+        help="""
+        This field computes a suggested price based on the 'Product Margin' 
+        field on Partners (Vendors), if it's set, or otherwise on the 'Product 
+        Margin' field in Product Categories (which has a default value).
+        """
     )
 
     deadline_for_sale = fields.Integer(string="Deadline for sale(days)")

--- a/beesdoo_product/models/beesdoo_product.py
+++ b/beesdoo_product/models/beesdoo_product.py
@@ -21,7 +21,7 @@ class ResPartner(models.Model):
     def _check_margin(self):
         for product in self:
             if product.profit_margin < 0.0:
-                raise UserError(_("Percentages for Profit Margin must > 0."))
+                raise UserError(_("Percentages for Profit Margin must >= 0."))
 
 
 class BeesdooProduct(models.Model):
@@ -321,7 +321,7 @@ class BeesdooProductCategory(models.Model):
     def _check_margin(self):
         for product in self:
             if product.profit_margin < 0.0:
-                raise UserError(_("Percentages for Profit Margin must > 0."))
+                raise UserError(_("Percentages for Profit Margin must >= 0."))
 
 
 class BeesdooProductSupplierInfo(models.Model):

--- a/beesdoo_product/models/beesdoo_product.py
+++ b/beesdoo_product/models/beesdoo_product.py
@@ -73,12 +73,14 @@ class BeesdooProduct(models.Model):
     note = fields.Text("Comments")
 
     suggested_price = fields.Float(
-        string="Suggested Price", compute="_compute_cost", readOnly=True,
+        string="Suggested Price",
+        compute="_compute_cost",
+        readOnly=True,
         help="""
         This field computes a suggested price based on the 'Product Margin' 
         field on Partners (Vendors), if it's set, or otherwise on the 'Product 
         Margin' field in Product Categories (which has a default value).
-        """
+        """,
     )
 
     deadline_for_sale = fields.Integer(string="Deadline for sale(days)")
@@ -276,9 +278,19 @@ class BeesdooProduct(models.Model):
                 profit_margin = (
                     profit_margin_supplier or profit_margin_product_category
                 )
+                suggested_price_reference = (
+                    self.env["ir.config_parameter"]
+                    .sudo()
+                    .get_param("beesdoo_product.suggested_price_reference")
+                )
+                factor = (
+                    1 / (1 - profit_margin / 100)
+                    if suggested_price_reference == "sale_price"
+                    else (1 + profit_margin / 100)
+                )
                 product.suggested_price = (
-                    price * product.uom_po_id.factor
-                ) * (1 + profit_margin / 100)
+                    price * product.uom_po_id.factor * factor
+                )
 
 
 class BeesdooScaleCategory(models.Model):

--- a/beesdoo_product/models/res_config_settings.py
+++ b/beesdoo_product/models/res_config_settings.py
@@ -9,8 +9,8 @@ class ResConfigSettings(models.TransientModel):
 
     suggested_price_reference = fields.Selection(
         selection=[
-            ("supplier_price", "Supplier Price"),
-            ("sale_price", "Sale Price"),
+            ("supplier_price", "On Supplier Price"),
+            ("sale_price", "On Sale Price"),
         ],
         string="Suggested price reference for margin",
         help="""

--- a/beesdoo_product/models/res_conig_settings.py
+++ b/beesdoo_product/models/res_conig_settings.py
@@ -1,0 +1,41 @@
+# Copyright 2019-2020 Elouan Le Bars <elouan@coopiteasy.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    suggested_price_reference = fields.Selection(
+        selection=[
+            ("supplier_price", "Supplier Price"),
+            ("sale_price", "Sale Price"),
+        ],
+        string="Suggested price reference for margin",
+        help="""
+            Price on which the margin is applied when computing the suggested sale price. 
+            - Margin on Supplier Price : Suggested sale price = supplier price * (1 + margin / 100) (default)
+            - Margin on Sale Price: Suggested sale price = supplier price * (1 / (1 - margin / 100))
+        """,
+        default="supplier_price",
+    )
+
+    @api.model
+    def get_values(self):
+        res = super(ResConfigSettings, self).get_values()
+        select_type = self.env["ir.config_parameter"].sudo()
+        suggested_price_reference = select_type.get_param(
+            "beesdoo_product.suggested_price_reference"
+        )
+        res.update({"suggested_price_reference": suggested_price_reference})
+        return res
+
+    @api.multi
+    def set_values(self):
+        super(ResConfigSettings, self).set_values()
+        select_type = self.env["ir.config_parameter"].sudo()
+        select_type.set_param(
+            "beesdoo_product.suggested_price_reference",
+            self.suggested_price_reference,
+        )

--- a/beesdoo_product/readme/DESCRIPTION.rst
+++ b/beesdoo_product/readme/DESCRIPTION.rst
@@ -4,3 +4,5 @@ Modification of product module for the needs of beescoop
 - The reference price on which this margin is applied (supplier price or sale price) can be selected in the general settings.
 - Also, sale and supplier taxes that are of type 'percentage' and that are marked as 'included in price' are taken into account when computing the suggested price.
 
+Please note that this model makes assumptions when computing the suggested price:
+- It supposes that each product has only one supplier and that products coming from multiple suppliers occure as duplicated products with one supplier each.

--- a/beesdoo_product/readme/DESCRIPTION.rst
+++ b/beesdoo_product/readme/DESCRIPTION.rst
@@ -1,3 +1,6 @@
 Modification of product module for the needs of beescoop
 - SOOO5 - Adds the label bio/ethique/provenance
 - Add a 'Suggested Price' field on products, and a 'Product Margin' field on Partners (Vendors) and Product Categories. The first margin is used if set, otherwise the second margin (which has a default value) is used.
+- The reference price on which this margin is applied (supplier price or sale price) can be selected in the general settings.
+- Also, sale and supplier taxes that are of type 'percentage' and that are marked as 'included in price' are taken into account when computing the suggested price.
+

--- a/beesdoo_product/readme/DESCRIPTION.rst
+++ b/beesdoo_product/readme/DESCRIPTION.rst
@@ -1,2 +1,3 @@
 Modification of product module for the needs of beescoop
-- SOOO5 - Ajout de label bio/ethique/provenance
+- SOOO5 - Adds the label bio/ethique/provenance
+- Add a 'Suggested exVAT Price' field on products, and a 'Product Margin' field on Partners (Vendors) and Product Categories. The first margin is used if set, otherwise the second margin (which has a default value) is used.

--- a/beesdoo_product/readme/DESCRIPTION.rst
+++ b/beesdoo_product/readme/DESCRIPTION.rst
@@ -1,3 +1,3 @@
 Modification of product module for the needs of beescoop
 - SOOO5 - Adds the label bio/ethique/provenance
-- Add a 'Suggested exVAT Price' field on products, and a 'Product Margin' field on Partners (Vendors) and Product Categories. The first margin is used if set, otherwise the second margin (which has a default value) is used.
+- Add a 'Suggested Price' field on products, and a 'Product Margin' field on Partners (Vendors) and Product Categories. The first margin is used if set, otherwise the second margin (which has a default value) is used.

--- a/beesdoo_product/views/beesdoo_product.xml
+++ b/beesdoo_product/views/beesdoo_product.xml
@@ -164,6 +164,17 @@
         </field>
     </record>
 
+    <record id="beesdoo_product_res_parter_form" model="ir.ui.view">
+        <field name="name">res.partner.form</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="arch" type="xml">
+            <group name="purchase" position="inside">
+                <field name="profit_margin"/>
+            </group>
+        </field>
+    </record>
+
     <record model="ir.ui.view" id="beesdoo_scale_category_list">
         <field name="name">beesdoo.scale.category.list</field>
         <field name="model">beesdoo.scale.category</field>

--- a/beesdoo_product/views/res_config_settings.xml
+++ b/beesdoo_product/views/res_config_settings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<odoo>
+
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.form</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="purchase.res_config_settings_view_form_purchase"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='group_manage_vendor_price']/../../.." position="inside">
+                <div class="col-xs-12 col-md-6 o_setting_box">
+                    <div class="o_setting_left_pane">
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="suggested_price_reference"/>
+                        <div class="text-muted">
+                            Price on which the margin is applied when computing the suggested sale price.<br/>
+                            - Margin on Supplier Price : Suggested sale price = supplier price * (1 + margin / 100) (default)<br/>
+                            - Margin on Sale Price: Suggested sale price = supplier price * (1 / (1 - margin / 100))
+                        </div>
+                        <div class="content-group">
+                            <div class="mt16">
+                                <field name="suggested_price_reference" class="o_light_label" widget="radio"/>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Add a 'Suggested exVAT Price' field on products, and a 'Product Margin' field on Partners (Vendors) and Product Categories. The first margin is used if set, otherwise the second margin (which has a default value) is used.