### PR TITLE
[12.0][ADD] beesdoo_product: Add "FDS" and "Danger particulier" field

### DIFF
--- a/beesdoo_product/__manifest__.py
+++ b/beesdoo_product/__manifest__.py
@@ -17,6 +17,7 @@
     "depends": ["beesdoo_base", "product", "sale", "point_of_sale"],
     "data": [
         "data/product_label.xml",
+        "data/product_hazard.xml",
         "data/barcode_rule.xml",
         "data/product_sequence.xml",
         "views/beesdoo_product.xml",

--- a/beesdoo_product/data/product_hazard.xml
+++ b/beesdoo_product/data/product_hazard.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record model="beesdoo.product.hazard" id="fds_required">
+            <field name="name">Required</field>
+            <field name="type">fds</field>
+        </record>
+        <record model="beesdoo.product.hazard" id="fds_not_required">
+            <field name="name">Not required</field>
+            <field name="type">fds</field>
+        </record>
+        <record model="beesdoo.product.hazard" id="fds_present">
+            <field name="name">Present</field>
+            <field name="type">fds</field>
+        </record>
+        <record model="beesdoo.product.hazard" id="hazard_none">
+            <field name="name">No</field>
+            <field name="type">hazard</field>
+        </record>
+        <record model="beesdoo.product.hazard" id="hazard_acid">
+            <field name="name">Acid</field>
+            <field name="type">hazard</field>
+        </record>
+        <record model="beesdoo.product.hazard" id="hazard_base">
+            <field name="name">Base</field>
+            <field name="type">hazard</field>
+        </record>
+        <record model="beesdoo.product.hazard" id="hazard_other">
+            <field name="name">Other danger</field>
+            <field name="type">hazard</field>
+        </record>
+    </data>
+</odoo>

--- a/beesdoo_product/i18n/fr_BE.po
+++ b/beesdoo_product/i18n/fr_BE.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 9.0c\n"
+"Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-13 15:12+0000\n"
-"PO-Revision-Date: 2016-11-13 15:12+0000\n"
+"POT-Creation-Date: 2020-08-03 09:47+0000\n"
+"PO-Revision-Date: 2020-08-03 09:47+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,142 +16,284 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: beesdoo_product
-#: model:ir.ui.view,arch_db:beesdoo_product.printing_label_request_wizard
-#: model:ir.ui.view,arch_db:beesdoo_product.set_label_as_printed_wizard
+#: model_terms:ir.ui.view,arch_db:beesdoo_product.printing_label_request_wizard
+#: model_terms:ir.ui.view,arch_db:beesdoo_product.set_label_as_printed_wizard
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_hazard__active
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_label__active
+msgid "Active"
+msgstr "Actif"
+
+#. module: beesdoo_product
+#: model_terms:ir.ui.view,arch_db:beesdoo_product.printing_label_request_wizard
+#: model_terms:ir.ui.view,arch_db:beesdoo_product.set_label_as_printed_wizard
 msgid "Cancel"
 msgstr "Annuler"
 
 #. module: beesdoo_product
-#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_label_color_code
-msgid "Color code"
-msgstr "Code Couleur"
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_scale_category__code
+msgid "Category code"
+msgstr "Code de catégorie"
 
 #. module: beesdoo_product
-#: model:ir.model.fields,field_description:beesdoo_product.field_product_template_note
+#: model:ir.model.fields,field_description:beesdoo_product.field_uom_category__type
+msgid "Category type"
+msgstr "Type de catégorie"
+
+#. module: beesdoo_product
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_label__color_code
+msgid "Color Code"
+msgstr "Code couleur"
+
+#. module: beesdoo_product
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__note
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__note
 msgid "Comments"
 msgstr "Commentaires"
 
 #. module: beesdoo_product
 #: model:account.tax.group,name:beesdoo_product.consignes_group_tax
 msgid "Consignes"
-msgstr "Consignes"
+msgstr ""
 
 #. module: beesdoo_product
-#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_label_create_uid
-#: model:ir.model.fields,field_description:beesdoo_product.field_label_printing_wizard_create_uid
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_hazard__create_uid
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_label__create_uid
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_scale_category__create_uid
+#: model:ir.model.fields,field_description:beesdoo_product.field_label_printing_wizard__create_uid
 msgid "Created by"
 msgstr "Créé par"
 
 #. module: beesdoo_product
-#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_label_create_date
-#: model:ir.model.fields,field_description:beesdoo_product.field_label_printing_wizard_create_date
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_hazard__create_date
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_label__create_date
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_scale_category__create_date
+#: model:ir.model.fields,field_description:beesdoo_product.field_label_printing_wizard__create_date
 msgid "Created on"
 msgstr "Créé le"
 
 #. module: beesdoo_product
-#: model:ir.model.fields,field_description:beesdoo_product.field_product_template_default_reference_unit
-msgid "Default reference unit"
-msgstr "Default reference unit"
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__deadline_for_consumption
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__deadline_for_consumption
+msgid "Deadline for consumption(days)"
+msgstr "Date limite de consommation(jours)"
 
 #. module: beesdoo_product
-#: model:ir.model.fields,field_description:beesdoo_product.field_product_template_total_deposit
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__deadline_for_sale
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__deadline_for_sale
+msgid "Deadline for sale(days)"
+msgstr "Date limite de vente(jours)"
+
+#. module: beesdoo_product
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__default_reference_unit
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__default_reference_unit
+msgid "Default Reference Unit"
+msgstr "Unité de référence par défaut"
+
+#. module: beesdoo_product
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__total_deposit
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__total_deposit
 msgid "Deposit Price"
-msgstr "Deposit Price"
+msgstr ""
 
 #. module: beesdoo_product
-#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_label_display_name
-#: model:ir.model.fields,field_description:beesdoo_product.field_label_printing_wizard_display_name
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_hazard__display_name
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_label__display_name
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_scale_category__display_name
+#: model:ir.model.fields,field_description:beesdoo_product.field_label_printing_wizard__display_name
 msgid "Display Name"
 msgstr "Nom affiché"
 
 #. module: beesdoo_product
-#: model:ir.model.fields,field_description:beesdoo_product.field_product_template_display_unit
-msgid "Display unit"
-msgstr "Display unit"
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__display_unit
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__display_unit
+msgid "Display Unit"
+msgstr ""
 
 #. module: beesdoo_product
-#: model:ir.model.fields,field_description:beesdoo_product.field_product_template_display_weight
-msgid "Display weight"
-msgstr "Display weight"
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__display_weight
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__display_weight
+msgid "Display Weight"
+msgstr ""
+
+#. module: beesdoo_product
+#: selection:uom.category,type:0
+msgid "Distance"
+msgstr ""
 
 #. module: beesdoo_product
 #: selection:beesdoo.product.label,type:0
 msgid "Distribution"
-msgstr "Distribution"
+msgstr ""
 
 #. module: beesdoo_product
-#: model:ir.model.fields,field_description:beesdoo_product.field_product_template_eco_label
-msgid "Eco label"
-msgstr "Eco label"
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__eco_label
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__eco_label
+msgid "Eco Label"
+msgstr ""
 
 #. module: beesdoo_product
-#: model:ir.model.fields,field_description:beesdoo_product.field_product_template_fair_label
-msgid "Fair label"
-msgstr "Fair label"
+#: selection:beesdoo.product.hazard,type:0
+msgid "FDS"
+msgstr ""
 
 #. module: beesdoo_product
-#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_label_id
-#: model:ir.model.fields,field_description:beesdoo_product.field_label_printing_wizard_id
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__fair_label
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__fair_label
+msgid "Fair Label"
+msgstr ""
+
+#. module: beesdoo_product
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__fds_label
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__fds_label
+msgid "Fds Label"
+msgstr "Libellé FDS"
+
+#. module: beesdoo_product
+#: model_terms:ir.ui.view,arch_db:beesdoo_product.beesdoo_product_form
+msgid "Generate Barcode"
+msgstr ""
+
+#. module: beesdoo_product
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__hazard_label
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__hazard_label
+msgid "Hazard Label"
+msgstr "Libellé de dangerosité"
+
+#. module: beesdoo_product
+#: model:ir.ui.menu,name:beesdoo_product.hazard_configuration_menu
+msgid "Hazards"
+msgstr "Dangers"
+
+#. module: beesdoo_product
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_hazard__id
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_label__id
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_scale_category__id
+#: model:ir.model.fields,field_description:beesdoo_product.field_label_printing_wizard__id
 msgid "ID"
-msgstr "ID"
+msgstr ""
 
 #. module: beesdoo_product
-#: model:ir.ui.view,arch_db:beesdoo_product.beesdoo_product_form
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__ingredients
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__ingredients
+msgid "Ingredient"
+msgstr "Ingrédient "
+
+#. module: beesdoo_product
+#: model_terms:ir.ui.view,arch_db:beesdoo_product.beesdoo_product_form
 msgid "Label"
-msgstr "Label"
+msgstr "Libellé"
 
 #. module: beesdoo_product
-#: model:ir.model.fields,field_description:beesdoo_product.field_product_template_label_last_printed
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__label_last_printed
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__label_last_printed
 msgid "Label last printed on"
-msgstr "Label last printed on"
+msgstr ""
 
 #. module: beesdoo_product
-#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_label___last_update
-#: model:ir.model.fields,field_description:beesdoo_product.field_label_printing_wizard___last_update
+#: model:ir.ui.menu,name:beesdoo_product.label_configuration_menu
+msgid "Labels"
+msgstr "Libellés"
+
+#. module: beesdoo_product
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_hazard____last_update
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_label____last_update
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_scale_category____last_update
+#: model:ir.model.fields,field_description:beesdoo_product.field_label_printing_wizard____last_update
 msgid "Last Modified on"
 msgstr "Dernière modification le"
 
 #. module: beesdoo_product
-#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_label_write_uid
-#: model:ir.model.fields,field_description:beesdoo_product.field_label_printing_wizard_write_uid
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_hazard__write_uid
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_label__write_uid
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_scale_category__write_uid
+#: model:ir.model.fields,field_description:beesdoo_product.field_label_printing_wizard__write_uid
 msgid "Last Updated by"
-msgstr "Mis à jour par"
+msgstr "Dernière mise à jour par"
 
 #. module: beesdoo_product
-#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_label_write_date
-#: model:ir.model.fields,field_description:beesdoo_product.field_label_printing_wizard_write_date
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_hazard__write_date
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_label__write_date
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_scale_category__write_date
+#: model:ir.model.fields,field_description:beesdoo_product.field_label_printing_wizard__write_date
 msgid "Last Updated on"
-msgstr "Mis à jour le"
+msgstr "Dernière mise à jour le"
 
 #. module: beesdoo_product
 #: selection:beesdoo.product.label,type:0
 msgid "Local"
-msgstr "Local"
+msgstr ""
 
 #. module: beesdoo_product
-#: model:ir.model.fields,field_description:beesdoo_product.field_product_template_local_label
-msgid "Local label"
-msgstr "Local label"
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__local_label
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__local_label
+msgid "Local Label"
+msgstr ""
 
 #. module: beesdoo_product
-#: model:ir.model.fields,field_description:beesdoo_product.field_product_template_main_seller_id
-msgid "Main seller id"
-msgstr "Main seller id"
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__main_seller_id
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__main_seller_id
+msgid "Main Seller"
+msgstr ""
 
 #. module: beesdoo_product
-#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_label_name
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_hazard__name
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_label__name
 msgid "Name"
 msgstr "Nom"
 
 #. module: beesdoo_product
-#: model:ir.model.fields,field_description:beesdoo_product.field_product_template_origin_label
-msgid "Origin label"
-msgstr "Origin label"
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__origin_label
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__origin_label
+msgid "Origin Label"
+msgstr ""
 
 #. module: beesdoo_product
-#: model:ir.model.fields,field_description:beesdoo_product.field_product_template_label_to_be_printed
+#: selection:uom.category,type:0
+msgid "Other"
+msgstr "Autre"
+
+#. module: beesdoo_product
+#: code:addons/beesdoo_product/models/beesdoo_product.py:327
+#, python-format
+msgid "Percentages for Profit Margin must > 0."
+msgstr ""
+
+#. module: beesdoo_product
+#: model:ir.model.fields,help:beesdoo_product.field_product_product__list_price
+#: model:ir.model.fields,help:beesdoo_product.field_product_template__list_price
+msgid "Price at which the product is sold to customers."
+msgstr "Prix auquel l'article est vendu aux clients."
+
+#. module: beesdoo_product
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__label_to_be_printed
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__label_to_be_printed
 msgid "Print label?"
-msgstr "Print label?"
+msgstr ""
+
+#. module: beesdoo_product
+#: model:ir.model.fields,field_description:beesdoo_product.field_label_printing_wizard__product_ids
+msgid "Product"
+msgstr "Article"
+
+#. module: beesdoo_product
+#: model:ir.model,name:beesdoo_product.model_product_category
+msgid "Product Category"
+msgstr "Catégorie d'article"
+
+#. module: beesdoo_product
+#: model:ir.actions.act_window,name:beesdoo_product.action_hazards
+msgid "Product Hazards"
+msgstr "Dangers d'article"
+
+#. module: beesdoo_product
+#: model:ir.actions.act_window,name:beesdoo_product.action_labels
+msgid "Product Labels"
+msgstr ""
+
+#. module: beesdoo_product
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_category__profit_margin
+msgid "Product Margin [%]"
+msgstr ""
 
 #. module: beesdoo_product
 #: model:ir.model,name:beesdoo_product.model_product_template
@@ -159,64 +301,187 @@ msgid "Product Template"
 msgstr "Modèle d'article"
 
 #. module: beesdoo_product
-#: model:ir.model.fields,field_description:beesdoo_product.field_label_printing_wizard_product_ids
-msgid "Product ids"
-msgstr "Product ids"
+#: model:ir.model,name:beesdoo_product.model_uom_category
+msgid "Product UoM Categories"
+msgstr "Catégorie d'UdM"
 
 #. module: beesdoo_product
-#: code:addons/beesdoo_product/models/beesdoo_product.py:56
+#: code:addons/beesdoo_product/models/beesdoo_product.py:250
 #, python-format
-msgid "Reference Unit and Display Unit should belong to the same category"
-msgstr "Reference Unit and Display Unit should belong to the same category"
+msgid "Reference Unit and Display Unit should belong to the same category "
+msgstr ""
 
 #. module: beesdoo_product
 #: model:ir.actions.act_window,name:beesdoo_product.beesdoo_product_action_request_label_printing
-#: model:ir.ui.view,arch_db:beesdoo_product.printing_label_request_wizard
+#: model_terms:ir.ui.view,arch_db:beesdoo_product.printing_label_request_wizard
 msgid "Request label printing"
-msgstr "Request label printing"
+msgstr ""
+
+#. module: beesdoo_product
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__scale_category
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__scale_category
+msgid "Scale Category"
+msgstr ""
+
+#. module: beesdoo_product
+#: model:ir.actions.act_window,name:beesdoo_product.action_scale_categories
+#: model:ir.ui.menu,name:beesdoo_product.scale_categories_configuration_menu
+msgid "Scale categories"
+msgstr ""
+
+#. module: beesdoo_product
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__scale_category_code
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__scale_category_code
+msgid "Scale category code"
+msgstr ""
+
+#. module: beesdoo_product
+#: model_terms:ir.ui.view,arch_db:beesdoo_product.beesdoo_product_form
+msgid "Scale labels"
+msgstr ""
+
+#. module: beesdoo_product
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__scale_label_info_1
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__scale_label_info_1
+msgid "Scale lable info 1"
+msgstr ""
+
+#. module: beesdoo_product
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__scale_label_info_2
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__scale_label_info_2
+msgid "Scale lable info 2"
+msgstr ""
+
+#. module: beesdoo_product
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_scale_category__name
+msgid "Scale name category"
+msgstr ""
+
+#. module: beesdoo_product
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__scale_sale_unit
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__scale_sale_unit
+msgid "Scale sale unit"
+msgstr ""
 
 #. module: beesdoo_product
 #: model:ir.actions.act_window,name:beesdoo_product.beesdoo_product_action_set_label_as_printed
 msgid "Set label as printed"
-msgstr "Set label as printed"
+msgstr ""
 
 #. module: beesdoo_product
-#: model:ir.ui.view,arch_db:beesdoo_product.set_label_as_printed_wizard
+#: model_terms:ir.ui.view,arch_db:beesdoo_product.set_label_as_printed_wizard
 msgid "Set labels as printed"
-msgstr "Set labels as printed"
+msgstr ""
 
 #. module: beesdoo_product
-#: model:ir.model.fields,field_description:beesdoo_product.field_product_template_total_with_vat
+#: code:addons/beesdoo_product/models/beesdoo_product.py:193
+#, python-format
+msgid "Several tax strategies (price_include) defined for %s"
+msgstr ""
+
+#. module: beesdoo_product
+#: selection:beesdoo.product.hazard,type:0
+msgid "Specific hazard"
+msgstr "Danger spécifique"
+
+#. module: beesdoo_product
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__suggested_price
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__suggested_price
+msgid "Suggested exVAT Price"
+msgstr ""
+
+#. module: beesdoo_product
+#: model:ir.model,name:beesdoo_product.model_product_supplierinfo
+msgid "Supplier Pricelist"
+msgstr "Liste de prix du fournisseur"
+
+#. module: beesdoo_product
+#: selection:uom.category,type:0
+msgid "Surface"
+msgstr ""
+
+#. module: beesdoo_product
+#: sql_constraint:beesdoo.scale.category:0
+msgid "The code of the scale category must be unique !"
+msgstr ""
+
+#. module: beesdoo_product
+#: model:ir.model.fields,help:beesdoo_product.field_product_supplierinfo__price
+msgid "The price to purchase a product"
+msgstr "Le prix pour l'achat d'un article"
+
+#. module: beesdoo_product
+#: selection:uom.category,type:0
+msgid "Time"
+msgstr ""
+
+#. module: beesdoo_product
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__total_with_vat
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__total_with_vat
 msgid "Total Sales Price with VAT"
-msgstr "Total Sales Price with VAT"
+msgstr ""
 
 #. module: beesdoo_product
-#: model:ir.model.fields,field_description:beesdoo_product.field_product_template_total_with_vat_by_unit
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__total_with_vat_by_unit
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__total_with_vat_by_unit
 msgid "Total Sales Price with VAT by Reference Unit"
-msgstr "Total Sales Price with VAT by Reference Unit"
+msgstr ""
 
 #. module: beesdoo_product
-#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_label_type
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_hazard__type
+#: model:ir.model.fields,field_description:beesdoo_product.field_beesdoo_product_label__type
 msgid "Type"
-msgstr "Type"
+msgstr ""
+
+#. module: beesdoo_product
+#: selection:uom.category,type:0
+msgid "Unit"
+msgstr "Unité"
+
+#. module: beesdoo_product
+#: selection:uom.category,type:0
+msgid "Volume"
+msgstr ""
+
+#. module: beesdoo_product
+#: selection:uom.category,type:0
+msgid "Weight"
+msgstr "Poids"
+
+#. module: beesdoo_product
+#: model:ir.model,name:beesdoo_product.model_beesdoo_product_hazard
+msgid "beesdoo.product.hazard"
+msgstr ""
 
 #. module: beesdoo_product
 #: model:ir.model,name:beesdoo_product.model_beesdoo_product_label
 msgid "beesdoo.product.label"
-msgstr "beesdoo.product.label"
+msgstr ""
+
+#. module: beesdoo_product
+#: model:ir.model,name:beesdoo_product.model_beesdoo_scale_category
+msgid "beesdoo.scale.category"
+msgstr ""
+
+#. module: beesdoo_product
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_product__list_price
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_supplierinfo__price
+#: model:ir.model.fields,field_description:beesdoo_product.field_product_template__list_price
+msgid "exVAT Price"
+msgstr ""
 
 #. module: beesdoo_product
 #: model:ir.model,name:beesdoo_product.model_label_printing_wizard
 msgid "label.printing.wizard"
-msgstr "label.printing.wizard"
+msgstr ""
 
 #. module: beesdoo_product
 #: selection:beesdoo.product.label,type:0
 msgid "Écologique"
-msgstr "Écologique"
+msgstr ""
 
 #. module: beesdoo_product
 #: selection:beesdoo.product.label,type:0
 msgid "Équitable"
-msgstr "Équitable"
+msgstr ""
 

--- a/beesdoo_product/models/beesdoo_product.py
+++ b/beesdoo_product/models/beesdoo_product.py
@@ -72,10 +72,8 @@ class BeesdooProduct(models.Model):
 
     note = fields.Text("Comments")
 
-    # S0023 : List_price = Price HTVA, so add a suggested price
-    list_price = fields.Float(string="exVAT Price")
     suggested_price = fields.Float(
-        string="Suggested exVAT Price", compute="_compute_cost", readOnly=True,
+        string="Suggested Price", compute="_compute_cost", readOnly=True,
         help="""
         This field computes a suggested price based on the 'Product Margin' 
         field on Partners (Vendors), if it's set, or otherwise on the 'Product 
@@ -332,7 +330,7 @@ class BeesdooProductCategory(models.Model):
 class BeesdooProductSupplierInfo(models.Model):
     _inherit = "product.supplierinfo"
 
-    price = fields.Float("exVAT Price")
+    price = fields.Float("Price")
 
 
 class BeesdooUOMCateg(models.Model):

--- a/beesdoo_product/models/beesdoo_product.py
+++ b/beesdoo_product/models/beesdoo_product.py
@@ -24,20 +24,53 @@ class ResPartner(models.Model):
                 raise UserError(_("Percentages for Profit Margin must >= 0."))
 
 
+class BeesdooProductHazard(models.Model):
+    _name = "beesdoo.product.hazard"
+    _description = "beesdoo.product.hazard"
+
+    name = fields.Char()
+    type = fields.Selection(
+        [
+            ("fds", "FDS"),
+            ("hazard", "Specific hazard"),
+        ]
+    )
+    active = fields.Boolean(default=True)
+
+
 class BeesdooProduct(models.Model):
     _inherit = "product.template"
 
     eco_label = fields.Many2one(
-        "beesdoo.product.label", domain=[("type", "=", "eco")]
+        "beesdoo.product.label",
+        domain=[("type", "=", "eco")]
     )
     local_label = fields.Many2one(
-        "beesdoo.product.label", domain=[("type", "=", "local")]
+        "beesdoo.product.label",
+        domain=[("type", "=", "local")]
     )
     fair_label = fields.Many2one(
-        "beesdoo.product.label", domain=[("type", "=", "fair")]
+        "beesdoo.product.label",
+        domain=[("type", "=", "fair")]
     )
     origin_label = fields.Many2one(
-        "beesdoo.product.label", domain=[("type", "=", "delivery")]
+        "beesdoo.product.label",
+        domain=[("type", "=", "delivery")]
+    )
+
+    fds_label = fields.Many2one(
+        "beesdoo.product.hazard",
+        string="FDS label",
+        domain=[("type", "=", "fds")],
+        translate=True,
+        default=lambda self: self.env['beesdoo.product.hazard'].search([["type", "=", "fds"],["name", "=", "Not required"]])
+    )
+    hazard_label = fields.Many2one(
+        "beesdoo.product.hazard",
+        string="Hazard label",
+        domain=[("type", "=", "hazard")],
+        translate=True,
+        default=lambda self: self.env['beesdoo.product.hazard'].search([["type", "=", "hazard"],["name", "=", "No"]])
     )
 
     main_seller_id = fields.Many2one(

--- a/beesdoo_product/models/beesdoo_product.py
+++ b/beesdoo_product/models/beesdoo_product.py
@@ -75,7 +75,12 @@ class BeesdooProduct(models.Model):
     # S0023 : List_price = Price HTVA, so add a suggested price
     list_price = fields.Float(string="exVAT Price")
     suggested_price = fields.Float(
-        string="Suggested exVAT Price", compute="_compute_cost", readOnly=True
+        string="Suggested exVAT Price", compute="_compute_cost", readOnly=True,
+        help="""
+        This field computes a suggested price based on the 'Product Margin' 
+        field on Partners (Vendors), if it's set, or otherwise on the 'Product 
+        Margin' field in Product Categories (which has a default value).
+        """
     )
 
     deadline_for_sale = fields.Integer(string="Deadline for sale(days)")

--- a/beesdoo_product/models/beesdoo_product.py
+++ b/beesdoo_product/models/beesdoo_product.py
@@ -21,7 +21,7 @@ class ResPartner(models.Model):
     def _check_margin(self):
         for product in self:
             if product.profit_margin < 0.0:
-                raise UserError(_("Percentages for Profit Margin must > 0."))
+                raise UserError(_("Percentages for Profit Margin must >= 0."))
 
 
 class BeesdooProduct(models.Model):
@@ -321,7 +321,7 @@ class BeesdooProductCategory(models.Model):
     def _check_margin(self):
         for product in self:
             if product.profit_margin < 0.0:
-                raise UserError(_("Percentages for Profit Margin must > 0."))
+                raise UserError(_("Percentages for Profit Margin must >= 0."))
 
 
 class BeesdooProductSupplierInfo(models.Model):

--- a/beesdoo_product/readme/DESCRIPTION.rst
+++ b/beesdoo_product/readme/DESCRIPTION.rst
@@ -1,2 +1,3 @@
 Modification of product module for the needs of beescoop
-- SOOO5 - Ajout de label bio/ethique/provenance
+- SOOO5 - Adds the label bio/ethique/provenance
+- Add a 'Suggested exVAT Price' field on products, and a 'Product Margin' field on Partners (Vendors) and Product Categories. The first margin is used if set, otherwise the second margin (which has a default value) is used.

--- a/beesdoo_product/readme/DESCRIPTION.rst
+++ b/beesdoo_product/readme/DESCRIPTION.rst
@@ -1,3 +1,3 @@
 Modification of product module for the needs of beescoop
 - SOOO5 - Adds the label bio/ethique/provenance
-- Add a 'Suggested exVAT Price' field on products, and a 'Product Margin' field on Partners (Vendors) and Product Categories. The first margin is used if set, otherwise the second margin (which has a default value) is used.
+- Add a 'Suggested Price' field on products, and a 'Product Margin' field on Partners (Vendors) and Product Categories. The first margin is used if set, otherwise the second margin (which has a default value) is used.

--- a/beesdoo_product/security/ir.model.access.csv
+++ b/beesdoo_product/security/ir.model.access.csv
@@ -1,4 +1,6 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+beesdoo_product_hazard_read_all,beesdoo.product.hazard Read All,model_beesdoo_product_hazard,,1,0,0,0
+beesdoo_product_hazard_all_access_sale_manager,beesdoo.product.hazard All Access Sale Manager,model_beesdoo_product_hazard,sales_team.group_sale_manager,1,1,1,1
 beesdoo_product_label_read_all,beesdoo.product.label Read All,model_beesdoo_product_label,,1,0,0,0
 beesdoo_product_label_all_access_sale_manager,beesdoo.product.label All Access Sale Manager,model_beesdoo_product_label,sales_team.group_sale_manager,1,1,1,1
 beesdoo_scale_category_read_all,beesdoo.scale.category Read All,model_beesdoo_scale_category,,1,0,0,0

--- a/beesdoo_product/views/beesdoo_product.xml
+++ b/beesdoo_product/views/beesdoo_product.xml
@@ -164,6 +164,17 @@
         </field>
     </record>
 
+    <record id="beesdoo_product_res_parter_form" model="ir.ui.view">
+        <field name="name">res.partner.form</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="arch" type="xml">
+            <group name="purchase" position="inside">
+                <field name="profit_margin"/>
+            </group>
+        </field>
+    </record>
+
     <record model="ir.ui.view" id="beesdoo_scale_category_list">
         <field name="name">beesdoo.scale.category.list</field>
         <field name="model">beesdoo.scale.category</field>

--- a/beesdoo_product/views/beesdoo_product.xml
+++ b/beesdoo_product/views/beesdoo_product.xml
@@ -46,6 +46,10 @@
                         </group>
                     </group>
                     <group>
+                        <field name="fds_label" widget="selection"/>
+                        <field name="hazard_label" widget="selection"/>
+                    </group>
+                    <group>
                         <field name="note"/>
                     </group>
                 </page>
@@ -110,6 +114,32 @@
         </field>
     </record>
 
+    <record model="ir.ui.view" id="beesdoo_product_hazard_form">
+        <field name="name">bees.product.hazard.form</field>
+        <field name="model">beesdoo.product.hazard</field>
+        <field name="arch" type="xml">
+            <form>
+                <group>
+                    <field name="name"/>
+                    <field name="type"/>
+                    <field name="active"/>
+                </group>
+            </form>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="beesdoo_product_hazard_tree">
+        <field name="name">bees.product.hazard.tree</field>
+        <field name="model">beesdoo.product.hazard</field>
+        <field name="arch" type="xml">
+            <tree editable="top">
+                <field name="name"/>
+                <field name="type"/>
+                <field name="active"/>
+            </tree>
+        </field>
+    </record>
+
     <record model="ir.ui.view" id="beesdoo_product_category_list">
         <field name="name">beesdoo.product.category.list</field>
         <field name="model">product.category</field>
@@ -149,9 +179,19 @@
         <field name="view_mode">tree,form</field>
     </record>
 
+    <record model="ir.actions.act_window" id="action_hazards">
+        <field name="name">Product Hazards</field>
+        <field name="res_model">beesdoo.product.hazard</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
     <menuitem id="label_configuration_menu" name="Labels"
               parent="sale.prod_config_main"
               action="action_labels" sequence="20"/>
+
+    <menuitem id="hazard_configuration_menu" name="Hazards"
+              parent="sale.prod_config_main"
+              action="action_hazards" sequence="30"/>
 
     <record id="beesdoo_product_uom_categ_form" model="ir.ui.view">
         <field name="name">uom.category.form</field>


### PR DESCRIPTION
Implements request 155 in file "20181114_Planification tache Odoo coop it easy"
# Request
Ajouter 2 champs à la vue article pour gérer les composantes chimiques des produits et leur danger possible
- champ "FDS", avec valeurs possibles : non requise (valeur par défaut), requise, présente
- champ "Danger particulier", avec valeurs possibles : non (valeur par défaut), acide, base, autre danger
# Status
Working but still missing:
- Translation of the "FDS" and "Danger particulier" field's values

Some questions also:
- I've created a new model, BeesdooProductHazard, for this (copied from BeesdooProductLabel). Should I rather use BeesdooProductLabel?
- On my dev instance, inactive records are not shown in tree views by default. This has the result that when I mark a label inactive it disappear from the view. Is it working the same way in production? If so, can/should we change that (at least for the BeesdooProductLabel and BeesdooProductHazard model)?