### PR TITLE
[FIX] b_shift: Group by status in kanban view

### DIFF
--- a/beesdoo_shift/models/task.py
+++ b/beesdoo_shift/models/task.py
@@ -89,7 +89,7 @@ class Task(models.Model):
     working_mode = fields.Selection(related="worker_id.working_mode")
 
     def _expand_states(self, states, domain, order):
-        return [key for key, val in self._fields["state"].selection]
+        return [key for key, val in self._fields["state"].selection(self)]
 
     @api.depends("state")
     def _compute_color(self):


### PR DESCRIPTION
@tfrancoi Pour info, ce fix résoud l'erreur suivante:

```
Traceback (most recent call last):
  File "/home/remy/Programmation/cie/env/odoo12/odoo/odoo/http.py", line 656, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/remy/Programmation/cie/env/odoo12/odoo/odoo/http.py", line 314, in _handle_exception
    raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])
  File "/home/remy/Programmation/cie/env/odoo12/odoo/odoo/tools/pycompat.py", line 87, in reraise
    raise value
  File "/home/remy/Programmation/cie/env/odoo12/odoo/odoo/http.py", line 698, in dispatch
    result = self._call_function(**self.params)
  File "/home/remy/Programmation/cie/env/odoo12/odoo/odoo/http.py", line 346, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/home/remy/Programmation/cie/env/odoo12/odoo/odoo/service/model.py", line 97, in wrapper
    return f(dbname, *args, **kwargs)
  File "/home/remy/Programmation/cie/env/odoo12/odoo/odoo/http.py", line 339, in checked_call
    result = self.endpoint(*a, **kw)
  File "/home/remy/Programmation/cie/env/odoo12/odoo/odoo/http.py", line 941, in __call__
    return self.method(*args, **kw)
  File "/home/remy/Programmation/cie/env/odoo12/odoo/odoo/http.py", line 519, in response_wrap
    response = f(*args, **kw)
  File "/home/remy/Programmation/cie/env/odoo12/odoo/addons/web/controllers/main.py", line 962, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/home/remy/Programmation/cie/env/odoo12/odoo/addons/web/controllers/main.py", line 954, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/home/remy/Programmation/cie/env/odoo12/odoo/odoo/api.py", line 755, in call_kw
    return _call_kw_model(method, model, args, kwargs)
  File "/home/remy/Programmation/cie/env/odoo12/odoo/odoo/api.py", line 728, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File "/home/remy/Programmation/cie/env/odoo12/odoo/odoo/models.py", line 2079, in read_group
    result = self._read_group_raw(domain, fields, groupby, offset=offset, limit=limit, orderby=orderby, lazy=lazy)
  File "/home/remy/Programmation/cie/env/odoo12/odoo/odoo/models.py", line 2215, in _read_group_raw
    aggregated_fields, count_field, result, read_group_order=order,
  File "/home/remy/Programmation/cie/env/odoo12/odoo/odoo/models.py", line 1743, in _read_group_fill_results
    values = getattr(self, field.group_expand)(values, domain, None)
  File "/home/remy/Programmation/cie/env/odoo12/coopiteasy/obeesdoo/beesdoo_shift/models/task.py", line 93, in _expand_states
TypeError: 'function' object is not iterable
```
Je fusionne, car j'en ai besoin ce weekend. S'il faut faire autrement préviens moi.