### PR TITLE
[FIX] beesdoo_base: partner form heritage

### DIFF
--- a/beesdoo_base/views/partner.xml
+++ b/beesdoo_base/views/partner.xml
@@ -18,7 +18,7 @@
         <field name="name">beesdoo.partner.form.view</field>
         <field name="model">res.partner</field>
         <field name="inherit_id"
-               ref="point_of_sale.view_partner_property_form"/>
+               ref="base.view_partner_form"/>
         <field name="arch" type="xml">
             <field name="website" position="after">
                 <field name="eater"


### PR DESCRIPTION
point_of_sale.view_partner_property_form is restricted to pos_users

-> change heritage to base in order to display member card information
   for regular beesdoo users

```xml
<!-- point of sale module -->

        <record id="view_partner_property_form" model="ir.ui.view">
            <field name="name">res.partner.pos.form.inherit</field>
            <field name="model">res.partner</field>
            <field name="inherit_id" ref="base.view_partner_form"/>
            <field name="priority" eval="4"/>
            <field name="groups_id" eval="[(4, ref('group_pos_user'))]"/>                   <-----
            <field name="arch" type="xml">
...
```