### PR TITLE
[12.0][ADD] beesdoo_pos: available_in_pos management

### DIFF
--- a/beesdoo_pos/README.rst
+++ b/beesdoo_pos/README.rst
@@ -19,7 +19,9 @@ Beescoop Point of sale
 
 |badge1| |badge2| |badge3| 
 
-This module adds the eaters of the customer to the POS ActionpadWidget and PaymentScreenWidget.
+This module :
+- adds the eaters of the customer to the POS ActionpadWidget and PaymentScreenWidget.
+- maintains "Available in POS" (`available_in_pos`) value when unchecking "Can be Sold" (`sale_ok`).
 
 **Table of contents**
 

--- a/beesdoo_pos/__manifest__.py
+++ b/beesdoo_pos/__manifest__.py
@@ -1,6 +1,7 @@
 # Copyright 2017 - 2020 BEES coop SCRLfs
 #   - Elouan Lebars <elouan@coopiteasy.be>
 #   - Rémy Taymans <remy@coopiteasy.be>
+#   - Vincent Van Rossem <vincent@coopiteasy.be>
 #   - Elise Dupont
 #   - Thibault François
 #   - Grégoire Leeuwerck
@@ -12,7 +13,7 @@
     "author": "Beescoop - Cellule IT, Coop IT Easy SCRLfs",
     "website": "https://github.com/beescoop/Obeesdoo",
     "category": "Point Of Sale",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.1.0",
     "depends": ["beesdoo_base", "beesdoo_product"],
     "data": ["views/beesdoo_pos.xml", "data/default_barcode_pattern.xml"],
     "qweb": ["static/src/xml/templates.xml"],

--- a/beesdoo_pos/models/__init__.py
+++ b/beesdoo_pos/models/__init__.py
@@ -1,1 +1,2 @@
 from . import beesdoo_pos
+from . import product

--- a/beesdoo_pos/models/product.py
+++ b/beesdoo_pos/models/product.py
@@ -1,0 +1,16 @@
+from odoo import api, fields, models, _
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    @api.onchange('sale_ok')
+    def _onchange_sale_ok(self):
+        """ Maintains the value of `available_in_pos` when unchecking `sale_ok`,
+            by storing its value before calling parent's method,
+            then assigning the stored value.
+        """
+        was_available = self.available_in_pos
+        super(ProductTemplate, self)._onchange_sale_ok()
+        if not self.sale_ok:
+            self.available_in_pos = was_available

--- a/beesdoo_pos/readme/DESCRIPTION.rst
+++ b/beesdoo_pos/readme/DESCRIPTION.rst
@@ -1,1 +1,3 @@
-This module adds the eaters of the customer to the POS ActionpadWidget and PaymentScreenWidget.
+This module :
+- adds the eaters of the customer to the POS ActionpadWidget and PaymentScreenWidget.
+- maintains "Available in POS" (`available_in_pos`) value when unchecking "Can be Sold" (`sale_ok`).

--- a/beesdoo_pos/static/description/index.html
+++ b/beesdoo_pos/static/description/index.html
@@ -368,7 +368,9 @@ ul.auto-toc {
 !! changes will be overwritten.                   !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external" href="https://github.com/beescoop/obeesdoo/tree/12.0/beesdoo_pos"><img alt="beescoop/obeesdoo" src="https://img.shields.io/badge/github-beescoop%2Fobeesdoo-lightgray.png?logo=github" /></a></p>
-<p>This module adds the eaters of the customer to the POS ActionpadWidget and PaymentScreenWidget.</p>
+<p>This module :
+- adds the eaters of the customer to the POS ActionpadWidget and PaymentScreenWidget.
+- maintains “Available in POS” (<cite>available_in_pos</cite>) value when unchecking “Can be Sold” (<cite>sale_ok</cite>).</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">


### PR DESCRIPTION
[Task](https://gestion.coopiteasy.be/web#id=5085&view_type=form&model=project.task&action=475&active_id=117)
This module maintains "Available in POS" (`available_in_pos`) value when unchecking "Can be Sold" (`sale_ok`).