### PR TITLE
[FIX] b_shift: Give read access to shift.template

### DIFF
--- a/beesdoo_shift/__manifest__.py
+++ b/beesdoo_shift/__manifest__.py
@@ -9,7 +9,7 @@
     "author": "Thibault Francois, Elouan Le Bars, Coop IT Easy SCRLfs",
     "website": "https://github.com/beescoop/Obeesdoo",
     "category": "Cooperative management",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.0.1",
     "depends": ["mail"],
     "data": [
         "data/system_parameter.xml",

--- a/beesdoo_shift/security/ir.model.access.csv
+++ b/beesdoo_shift/security/ir.model.access.csv
@@ -1,6 +1,6 @@
 id,name,model_id/id,group_id/id,perm_read,perm_write,perm_create,perm_unlink
 read_beesdoo_shift_planning,read_beesdoo_shift_planning,model_beesdoo_shift_planning,,1,0,0,0
-access_beesdoo_shift_template,access_beesdoo_shift_template,model_beesdoo_shift_template,group_shift_attendance,1,0,0,0
+access_beesdoo_shift_template,access_beesdoo_shift_template,model_beesdoo_shift_template,,1,0,0,0
 write_beesdoo_shift_shift,write_beesdoo_shift_shift,model_beesdoo_shift_shift,group_shift_attendance,1,1,0,0
 manage_beesdoo_shift_shift,manage_beesdoo_shift_shift,model_beesdoo_shift_shift,group_shift_attendance,1,1,1,1
 manage_beesdoo_shift_type,manage_beesdoo_shift_type,model_beesdoo_shift_type,group_planning_management,1,1,1,1


### PR DESCRIPTION
In order to allow user to create a simple partner or a supplier they need to have read access to shift.template as b_shift add a field related to a shift.template (subscribed_shift_ids).

See task https://gestion.coopiteasy.be/web#id=5103&view_type=form&model=project.task&action=475&active_id=117