### PR TITLE
[12.0] beesdoo_purchase : adapt product purchase and/or selling price on PO confirmation

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -9,4 +9,4 @@ line_length = 79
 known_odoo = odoo
 known_odoo_addons = odoo.addons
 sections = FUTURE,STDLIB,THIRDPARTY,ODOO,ODOO_ADDONS,FIRSTPARTY,LOCALFOLDER
-known_third_party = pytz
+known_third_party = pytz,setuptools

--- a/beesdoo_purchase/views/purchase_order.xml
+++ b/beesdoo_purchase/views/purchase_order.xml
@@ -7,16 +7,15 @@
             <field name="arch" type="xml">
                 <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
                     <button name="action_toggle_adapt_purchase_price" type="object"
-                            string="Adapt Purchase Price"
+                            string="Toggle Purchase Price"
                             icon="fa-check-square"
                             class="oe_stat_button"
-                            help="TODO"/>
+                            help="Toggle Purchase Price checkboxes to adapt the purchase price on the product page when confirming Purchase Order"/>
                     <button name="action_toggle_adapt_selling_price" type="object"
-                            string="Toggle To Selling Price"
-                            icon="fa-toggle-on"
+                            string="Toggle Selling Price"
+                            icon="fa-check-square"
                             class="oe_stat_button"
-                            attrs="{'invisible': True}"
-                            help="TODO"/>
+                            help="Toggle Selling Price checkboxes to adapt the selling price on the product page when confirming Purchase Order"/>
                 </xpath>
                 <field name="date_order" position="after">
                     <field name="supervisor_id"/>
@@ -28,8 +27,8 @@
                     </attribute>
                 </field>
                 <field name="price_subtotal" position="after">
-                    <field name="adapt_purchase_price" string="To purchase price"/>
-                    <field name="adapt_selling_price" string="To selling price" invisible="True"/>
+                    <field name="adapt_purchase_price" string="Is Purchase Price"/>
+                    <field name="adapt_selling_price" string="Is Selling Price"/>
                 </field>
             </field>
         </record>

--- a/beesdoo_purchase/views/purchase_order.xml
+++ b/beesdoo_purchase/views/purchase_order.xml
@@ -7,12 +7,22 @@
             <field name="arch" type="xml">
                 <field name="date_order" position="after">
                     <field name="supervisor_id"/>
+                    <button name="action_toggle_adapt_purchase_price" type="object"
+                            string="Toggle To Purchase Price"
+                            help="TODO"/>
+                    <button name="action_toggle_adapt_purchase_price" type="object"
+                            string="Toggle To Selling Price"
+                            help="TODO"/>
                 </field>
                 <field name="product_id" position="attributes">
                     <attribute name="domain">[
                         ('main_seller_id','=', parent.partner_id),
                         ('purchase_ok', '=', True) ]
                     </attribute>
+                </field>
+                <field name="price_subtotal" position="after">
+                    <field name="adapt_purchase_price" string="To purchase price"/>
+                    <field name="adapt_selling_price" string="To selling price"/>
                 </field>
             </field>
         </record>

--- a/beesdoo_purchase/views/purchase_order.xml
+++ b/beesdoo_purchase/views/purchase_order.xml
@@ -5,14 +5,21 @@
             <field name="model">purchase.order</field>
             <field name="inherit_id" ref="purchase.purchase_order_form"/>
             <field name="arch" type="xml">
+                <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
+                    <button name="action_toggle_adapt_purchase_price" type="object"
+                            string="Adapt Purchase Price"
+                            icon="fa-check-square"
+                            class="oe_stat_button"
+                            help="TODO"/>
+                    <button name="action_toggle_adapt_selling_price" type="object"
+                            string="Toggle To Selling Price"
+                            icon="fa-toggle-on"
+                            class="oe_stat_button"
+                            attrs="{'invisible': True}"
+                            help="TODO"/>
+                </xpath>
                 <field name="date_order" position="after">
                     <field name="supervisor_id"/>
-                    <button name="action_toggle_adapt_purchase_price" type="object"
-                            string="Toggle To Purchase Price"
-                            help="TODO"/>
-                    <button name="action_toggle_adapt_purchase_price" type="object"
-                            string="Toggle To Selling Price"
-                            help="TODO"/>
                 </field>
                 <field name="product_id" position="attributes">
                     <attribute name="domain">[
@@ -22,7 +29,7 @@
                 </field>
                 <field name="price_subtotal" position="after">
                     <field name="adapt_purchase_price" string="To purchase price"/>
-                    <field name="adapt_selling_price" string="To selling price"/>
+                    <field name="adapt_selling_price" string="To selling price" invisible="True"/>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
[Task](https://gestion.coopiteasy.be/web#id=5144&view_type=form&model=project.task)

This new feature allows an user to adapt the purchase price and/or the selling price of a product, when confirming a purchase order.

- added 2 "Toggle Purchase/Selling Price" buttons on the PO header
- added 2 "Is Purchase/Selling Price" columns on the PO lines

![adapt-purchase-selling-price](https://user-images.githubusercontent.com/28013700/99059314-b6fc9880-259e-11eb-895c-dd546cb513fd.png)
