### PR TITLE
[FIX] beesdoo_website_shift: shift_irregular_worker noupdate false

### DIFF
--- a/beesdoo_website_shift/views/shift_website_templates.xml
+++ b/beesdoo_website_shift/views/shift_website_templates.xml
@@ -6,7 +6,7 @@
 <odoo>
 
     <!-- Add menu entries -->
-    <data noupdate="1">
+    <data noupdate="0">
         <record id="menu_work_irregular" model="website.menu">
             <field name="name">Shifts Irregular</field>
             <field name="url">/shift_irregular_worker</field>


### PR DESCRIPTION
[Task](https://gestion.coopiteasy.be/web?token=R0Qs92cjQIn6BsLb5XTZ&db=coopiteasy#id=4925&view_type=form&model=project.task&action=479)

Set `noupdate = false` on the `shift_irregular_worker` pages.