### PR TITLE
[12.0][IMP] beesdoo_purchase: button to adapt purchase/selling price

### DIFF
--- a/beesdoo_purchase/README.rst
+++ b/beesdoo_purchase/README.rst
@@ -20,14 +20,16 @@ Bees Purchase
 |badge1| |badge2| |badge3| 
 
 Extends Purchase module:
+
 - Adds a 'Responsible' field to purchase orders:
-This is a user who will follow up the order. This users replaces
-the creator in the order's mail messages followers list, and in the
-create_uid ORM field. His user's contact info is printed on
-purchases orders as 'Referent'.
+  This is a user who will follow up the order. This users replaces
+  the creator in the order's mail messages followers list, and in the
+  create_uid ORM field. His user's contact info is printed on
+  purchases orders as 'Referent'.
 - A filter w.r.t. the mail sellers is placed on the products field of a
-purchase order.
-- Allow inverting the Purchase Order Reference on the invoice lines.
+  purchase order.
+- Allows inverting the Purchase Order (PO) Reference on the invoice lines.
+- Allows adapting a product's purchase and/or selling price from a PO.
 
 **Table of contents**
 

--- a/beesdoo_purchase/__manifest__.py
+++ b/beesdoo_purchase/__manifest__.py
@@ -1,15 +1,13 @@
 {
     "name": "Bees Purchase",
     "summary": """
-        - Adds a 'Responsible' field to purchase orders
-        - A filter w.r.t. the mail sellers is placed on the products field of a
-        purchase order
-        - Allow inverting the Purchase Order Reference on the invoice lines
+        Enhancements related to Purchase module :
+        field, filter, PO reference, product's purchase and/or selling price
     """,
     "author": "Beescoop - Cellule IT, " "Coop IT Easy SCRLfs",
     "website": "https://github.com/beescoop/Obeesdoo",
     "category": "Purchase",
-    "version": "12.0.1.2.0",
+    "version": "12.0.1.3.0",
     "depends": ["base", "purchase", "beesdoo_product"],
     "data": [
         "security/invoice_security.xml",

--- a/beesdoo_purchase/models/purchase.py
+++ b/beesdoo_purchase/models/purchase.py
@@ -1,4 +1,5 @@
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 
 class PurchaseOrder(models.Model):
@@ -16,6 +17,8 @@ class PurchaseOrder(models.Model):
         required=True,
         default=lambda self: self.env.user,
     )
+    select_all_purchase_price = fields.Boolean(default=False)
+    select_all_selling_price = fields.Boolean(default=False)
 
     @api.depends("supervisor_id")
     def _compute_create_uid(self):
@@ -41,45 +44,64 @@ class PurchaseOrder(models.Model):
         return super(PurchaseOrder, self).write(vals)
 
     @api.multi
-    def action_toggle_adapt_purchase_price(self):
+    def action_select_deselect_adapt_purchase_price(self):
+        self.select_all_purchase_price = not self.select_all_purchase_price
         for order in self:
             for line in order.order_line:
-                line.adapt_purchase_price ^= True
+                line.adapt_purchase_price = self.select_all_purchase_price
 
     @api.multi
-    def action_toggle_adapt_selling_price(self):
+    def action_select_deselect_adapt_selling_price(self):
+        self.select_all_selling_price = not self.select_all_selling_price
         for order in self:
             for line in order.order_line:
-                line.adapt_selling_price ^= True
+                line.adapt_selling_price = self.select_all_selling_price
 
     @api.multi
-    def button_confirm(self):
-        res = super(PurchaseOrder, self).button_confirm()
+    def button_adapt_price(self):
         for order in self:
-            for line in order.order_line:
+            lines = order.order_line.filtered(
+                lambda l: l.adapt_purchase_price or l.adapt_selling_price
+            )
+            for line in lines:
                 product_id = line.product_id
                 product_tmpl_id = product_id.product_tmpl_id
                 seller = product_id._select_seller(
-                    partner_id=line.order_id.partner_id,
+                    partner_id=line.partner_id,
                     quantity=line.product_qty,
-                    date=order.date_order and order.date_order.date(),
+                    date=line.order_id.date_order
+                    and line.order_id.date_order.date(),
                     uom_id=line.product_uom,
                     params={"order_id": line.order_id},
                 )
-                price = line.price_unit
-                suggested_price = (
-                    price * product_tmpl_id.uom_po_id.factor
-                ) * (1 + product_tmpl_id.categ_id.profit_margin / 100)
-                if line.adapt_purchase_price and line.adapt_selling_price:
-                    seller.price = price
-                    # will asynchronously trigger _compute_cost()
-                    # on `product.template` in `beesdoo_product`
-                    product_tmpl_id.list_price = suggested_price
-                elif line.adapt_purchase_price:
-                    seller.price = price  # see above comment
-                elif line.adapt_selling_price:
-                    product_tmpl_id.list_price = suggested_price
-        return res
+                if seller:
+                    price = line.price_unit
+                    suggested_price = (
+                        price * product_tmpl_id.uom_po_id.factor
+                    ) * (1 + product_tmpl_id.categ_id.profit_margin / 100)
+                    if line.adapt_purchase_price and line.adapt_selling_price:
+                        # will asynchronously trigger _compute_cost()
+                        # on `product.template` in `beesdoo_product`
+                        seller.price = price
+                        product_tmpl_id.list_price = suggested_price
+                    elif line.adapt_purchase_price:
+                        seller.price = price  # see above comment
+                    elif line.adapt_selling_price:
+                        product_tmpl_id.list_price = suggested_price
+                else:
+                    raise UserError(
+                        _(
+                            "Odoo cannot adapt the price of '%s'.\n"
+                            "Please check the Vendor's line on the product page.\n"
+                            "Make sure everything is consistent, in particular:\n"
+                            "- the purchased quantity might be lower than "
+                            "the minimal quantity defined for this vendor\n"
+                            "- there might be an issue with the dates "
+                            "if there are existing dates on the vendor's line "
+                            "for this product."
+                        )
+                        % product_id.name
+                    )
 
 
 class PurchaseOrderLine(models.Model):

--- a/beesdoo_purchase/readme/DESCRIPTION.rst
+++ b/beesdoo_purchase/readme/DESCRIPTION.rst
@@ -1,9 +1,11 @@
 Extends Purchase module:
+
 - Adds a 'Responsible' field to purchase orders:
-This is a user who will follow up the order. This users replaces
-the creator in the order's mail messages followers list, and in the
-create_uid ORM field. His user's contact info is printed on
-purchases orders as 'Referent'.
+  This is a user who will follow up the order. This users replaces
+  the creator in the order's mail messages followers list, and in the
+  create_uid ORM field. His user's contact info is printed on
+  purchases orders as 'Referent'.
 - A filter w.r.t. the mail sellers is placed on the products field of a
-purchase order.
-- Allow inverting the Purchase Order Reference on the invoice lines.
+  purchase order.
+- Allows inverting the Purchase Order (PO) Reference on the invoice lines.
+- Allows adapting a product's purchase and/or selling price from a PO.

--- a/beesdoo_purchase/static/description/index.html
+++ b/beesdoo_purchase/static/description/index.html
@@ -368,15 +368,18 @@ ul.auto-toc {
 !! changes will be overwritten.                   !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external" href="https://github.com/beescoop/obeesdoo/tree/12.0/beesdoo_purchase"><img alt="beescoop/obeesdoo" src="https://img.shields.io/badge/github-beescoop%2Fobeesdoo-lightgray.png?logo=github" /></a></p>
-<p>Extends Purchase module:
-- Adds a ‘Responsible’ field to purchase orders:
+<p>Extends Purchase module:</p>
+<ul class="simple">
+<li>Adds a ‘Responsible’ field to purchase orders:
 This is a user who will follow up the order. This users replaces
 the creator in the order’s mail messages followers list, and in the
 create_uid ORM field. His user’s contact info is printed on
-purchases orders as ‘Referent’.
-- A filter w.r.t. the mail sellers is placed on the products field of a
-purchase order.
-- Allow inverting the Purchase Order Reference on the invoice lines.</p>
+purchases orders as ‘Referent’.</li>
+<li>A filter w.r.t. the mail sellers is placed on the products field of a
+purchase order.</li>
+<li>Allows inverting the Purchase Order (PO) Reference on the invoice lines.</li>
+<li>Allows adapting a product’s purchase and/or selling price from a PO.</li>
+</ul>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/beesdoo_purchase/views/purchase_order.xml
+++ b/beesdoo_purchase/views/purchase_order.xml
@@ -5,20 +5,39 @@
             <field name="model">purchase.order</field>
             <field name="inherit_id" ref="purchase.purchase_order_form"/>
             <field name="arch" type="xml">
+                <xpath expr="//header" position="inside">
+                     <button name="button_adapt_price" states="draft,sent,purchase" string="Adapt Prices" type="object" />
+                </xpath>
                 <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
-                    <button name="action_toggle_adapt_purchase_price" type="object"
-                            string="Toggle Purchase Price"
+                    <button name="action_select_deselect_adapt_purchase_price" type="object"
+                            attrs="{'invisible': [('select_all_purchase_price', '=', False)]}"
+                            string="Deselect All Is Purchase Price"
+                            icon="fa-square-o"
+                            class="oe_stat_button"
+                            help="Deselect All Is Purchase Price checkboxes to adapt the purchase price on the product page when confirming Purchase Order"/>
+                    <button name="action_select_deselect_adapt_purchase_price" type="object"
+                            attrs="{'invisible': [('select_all_purchase_price', '=', True)]}"
+                            string="Select All Is Purchase Price"
                             icon="fa-check-square"
                             class="oe_stat_button"
-                            help="Toggle Purchase Price checkboxes to adapt the purchase price on the product page when confirming Purchase Order"/>
-                    <button name="action_toggle_adapt_selling_price" type="object"
-                            string="Toggle Selling Price"
+                            help="Select All Is Purchase Price checkboxes to adapt the purchase price on the product page when confirming Purchase Order"/>
+                    <button name="action_select_deselect_adapt_selling_price" type="object"
+                            attrs="{'invisible': [('select_all_selling_price', '=', False)]}"
+                            string="Deselect All Is Selling Price"
+                            icon="fa-square-o"
+                            class="oe_stat_button"
+                            help="Deselect All Is Selling Price checkboxes to adapt the selling price on the product page when confirming Purchase Order"/>
+                    <button name="action_select_deselect_adapt_selling_price" type="object"
+                            attrs="{'invisible': [('select_all_selling_price', '=', True)]}"
+                            string="Select All Is Selling Price"
                             icon="fa-check-square"
                             class="oe_stat_button"
-                            help="Toggle Selling Price checkboxes to adapt the selling price on the product page when confirming Purchase Order"/>
+                            help="Select All Is Selling Price checkboxes to adapt the selling price on the product page when confirming Purchase Order"/>
                 </xpath>
                 <field name="date_order" position="after">
                     <field name="supervisor_id"/>
+                    <field name="select_all_purchase_price" invisible="1"/>
+                    <field name="select_all_selling_price" invisible="1"/>
                 </field>
                 <field name="product_id" position="attributes">
                     <attribute name="domain">[


### PR DESCRIPTION
[Task](https://gestion.coopiteasy.be/web#id=5545&view_type=form&model=project.task)
**Before**
Purchase and/or selling price was adapted when confirming PO.

**After**
Purchase and/or selling price is now adapted when using button "Adapt Prices".
- button is visible only for the following states: `draft,sent,purchase`
- replaced toggle buttons with select/deselect all
- performance: loops only the lines with `adapt_[purchase|selling]_price` set
- raise an UserError if no seller (`product.supplierinfo`) is found
  when using standard method `_select_seller` from `product.product`.
  A reason could be that the product's ordered `quantity` is lower than
  the seller `min_qty`