### PR TITLE
[12.0][ADD] beesdoo_product : quick price editing

### DIFF
--- a/beesdoo_product/README.rst
+++ b/beesdoo_product/README.rst
@@ -20,7 +20,33 @@ beesdoo_product
 |badge1| |badge2| |badge3| 
 
 Modification of product module for the needs of beescoop
-- SOOO5 - Ajout de label bio/ethique/provenance
+
+- Adds the label bio/ethique/provenance
+- Add a 'Suggested Price' field on products, and a 'Product Margin' field on Partners (Vendors) and Product Categories.
+  The first margin is used if set, otherwise the second margin (which has a default value) is used.
+- The reference price on which this margin is applied (supplier price or sale price)
+  can be selected in the general settings.
+- Also, sale and supplier taxes that are of type 'percentage' and that are marked as 'included in price'
+  are taken into account when computing the suggested price.
+- Adds "Edit Price" submenu on Point Of Sale, Purchase and Sale modules.
+  The user lands on an editable List View with the following columns :
+
+  - Name (`name`)
+  - Main Seller (`main_seller_id`)
+  - Purchase Price (`purchase_price`)
+  - Purchase Unit of Measure (`uom_po_id`)
+  - Suggested Price (`suggested_price`)
+  - Sales Price (`list_price`)
+  - Unit of Measure (`uom_id`)
+
+  The only editable field is Purchase Price.
+  Through "Action > Adapt Sales Price", the user can, on the selected products,
+  adapt the Sales Price according to the Suggested Price.
+
+Please note that this model makes assumptions when computing the suggested price:
+
+- It supposes that each product has only one supplier and that products coming from multiple suppliers
+  occure as duplicated products with one supplier each.
 
 **Table of contents**
 

--- a/beesdoo_product/__manifest__.py
+++ b/beesdoo_product/__manifest__.py
@@ -3,6 +3,7 @@
 #   - Rémy Taymans <remy@coopiteasy.be>
 #   - Houssine BAKKALI <houssine@coopiteasy.be>
 #   - Manuel Claeys Bouuaert <manuel@coopiteasy.be>
+#   - Vincent Van Rossem <vincent@coopiteasy.be>
 #   - Elise Dupont
 #   - Thibault François
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
@@ -10,20 +11,30 @@
     "name": "beesdoo_product",
     "summary": """
         Modification of product module for the needs of beescoop
-        - SOOO5 - Ajout de label bio/ethique/provenance""",
+        """,
     "author": "Beescoop - Cellule IT, Coop IT Easy SCRLfs",
     "website": "https://github.com/beescoop/Obeesdoo",
     "category": "Sales",
-    "version": "12.0.1.0.1",
-    "depends": ["beesdoo_base", "product", "sale", "point_of_sale"],
+    "version": "12.0.1.1.1",
+    "depends": [
+        "beesdoo_base",
+        "product",
+        "sale",
+        "point_of_sale",
+        "purchase",
+    ],
     "data": [
         "data/product_label.xml",
         "data/product_hazard.xml",
         "data/barcode_rule.xml",
         "data/product_sequence.xml",
         "views/beesdoo_product.xml",
+        "views/point_of_sale_view.xml",
+        "views/purchase_views.xml",
+        "views/sale_views.xml",
         "views/assets.xml",
         "views/res_config_settings.xml",
+        "wizard/views/adapt_sales_price_wizard_view.xml",
         "wizard/views/label_printing_utils.xml",
         "security/ir.model.access.csv",
     ],

--- a/beesdoo_product/readme/DESCRIPTION.rst
+++ b/beesdoo_product/readme/DESCRIPTION.rst
@@ -1,8 +1,28 @@
 Modification of product module for the needs of beescoop
-- SOOO5 - Adds the label bio/ethique/provenance
-- Add a 'Suggested Price' field on products, and a 'Product Margin' field on Partners (Vendors) and Product Categories. The first margin is used if set, otherwise the second margin (which has a default value) is used.
-- The reference price on which this margin is applied (supplier price or sale price) can be selected in the general settings.
-- Also, sale and supplier taxes that are of type 'percentage' and that are marked as 'included in price' are taken into account when computing the suggested price.
+
+- Adds the label bio/ethique/provenance
+- Add a 'Suggested Price' field on products, and a 'Product Margin' field on Partners (Vendors) and Product Categories.
+  The first margin is used if set, otherwise the second margin (which has a default value) is used.
+- The reference price on which this margin is applied (supplier price or sale price)
+  can be selected in the general settings.
+- Also, sale and supplier taxes that are of type 'percentage' and that are marked as 'included in price'
+  are taken into account when computing the suggested price.
+- Adds "Edit Price" submenu on Point Of Sale, Purchase and Sale modules.
+  The user lands on an editable List View with the following columns :
+
+  - Name (`name`)
+  - Main Seller (`main_seller_id`)
+  - Purchase Price (`purchase_price`)
+  - Purchase Unit of Measure (`uom_po_id`)
+  - Suggested Price (`suggested_price`)
+  - Sales Price (`list_price`)
+  - Unit of Measure (`uom_id`)
+
+  The only editable field is Purchase Price.
+  Through "Action > Adapt Sales Price", the user can, on the selected products,
+  adapt the Sales Price according to the Suggested Price.
 
 Please note that this model makes assumptions when computing the suggested price:
-- It supposes that each product has only one supplier and that products coming from multiple suppliers occure as duplicated products with one supplier each.
+
+- It supposes that each product has only one supplier and that products coming from multiple suppliers
+  occure as duplicated products with one supplier each.

--- a/beesdoo_product/static/description/index.html
+++ b/beesdoo_product/static/description/index.html
@@ -368,8 +368,40 @@ ul.auto-toc {
 !! changes will be overwritten.                   !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external" href="https://github.com/beescoop/obeesdoo/tree/12.0/beesdoo_product"><img alt="beescoop/obeesdoo" src="https://img.shields.io/badge/github-beescoop%2Fobeesdoo-lightgray.png?logo=github" /></a></p>
-<p>Modification of product module for the needs of beescoop
-- SOOO5 - Ajout de label bio/ethique/provenance</p>
+<p>Modification of product module for the needs of beescoop</p>
+<ul>
+<li><p class="first">Adds the label bio/ethique/provenance</p>
+</li>
+<li><p class="first">Add a ‘Suggested Price’ field on products, and a ‘Product Margin’ field on Partners (Vendors) and Product Categories.
+The first margin is used if set, otherwise the second margin (which has a default value) is used.</p>
+</li>
+<li><p class="first">The reference price on which this margin is applied (supplier price or sale price)
+can be selected in the general settings.</p>
+</li>
+<li><p class="first">Also, sale and supplier taxes that are of type ‘percentage’ and that are marked as ‘included in price’
+are taken into account when computing the suggested price.</p>
+</li>
+<li><p class="first">Adds “Edit Price” submenu on Point Of Sale, Purchase and Sale modules.
+The user lands on an editable List View with the following columns :</p>
+<ul class="simple">
+<li>Name (<cite>name</cite>)</li>
+<li>Main Seller (<cite>main_seller_id</cite>)</li>
+<li>Purchase Price (<cite>purchase_price</cite>)</li>
+<li>Purchase Unit of Measure (<cite>uom_po_id</cite>)</li>
+<li>Suggested Price (<cite>suggested_price</cite>)</li>
+<li>Sales Price (<cite>list_price</cite>)</li>
+<li>Unit of Measure (<cite>uom_id</cite>)</li>
+</ul>
+<p>The only editable field is Purchase Price.
+Through “Action &gt; Adapt Sales Price”, the user can, on the selected products,
+adapt the Sales Price according to the Suggested Price.</p>
+</li>
+</ul>
+<p>Please note that this model makes assumptions when computing the suggested price:</p>
+<ul class="simple">
+<li>It supposes that each product has only one supplier and that products coming from multiple suppliers
+occure as duplicated products with one supplier each.</li>
+</ul>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/beesdoo_product/views/beesdoo_product.xml
+++ b/beesdoo_product/views/beesdoo_product.xml
@@ -86,6 +86,25 @@
         </field>
     </record>
 
+    <record id="product_template_edit_price_tree_view" model="ir.ui.view">
+        <field name="name">product.template.edit.price.tree</field>
+        <field name="model">product.template</field>
+        <field name="arch" type="xml">
+            <tree string="Product" editable="top" edit="true">
+                <field name="name" readonly="1"/>
+                <field name="main_seller_id" string="Main Seller" readonly="1"
+                       options="{'no_open': True, 'no_create': True, 'no_create_edit': True }"/>
+                <field name="purchase_price"/>
+                <field name="uom_po_id" readonly="1"
+                       options="{'no_open': True, 'no_create': True, 'no_create_edit':True }"/>
+                <field name="suggested_price" readonly="1"/>
+                <field name="list_price" readonly="1"/>
+                <field name="uom_id" readonly="1"
+                       options="{'no_open': True, 'no_create': True, 'no_create_edit':True }"/>
+            </tree>
+        </field>
+    </record>
+
     <record model="ir.ui.view" id="beesdoo_product_label_form">
         <field name="name">bees.product.label.form</field>
         <field name="model">beesdoo.product.label</field>

--- a/beesdoo_product/views/point_of_sale_view.xml
+++ b/beesdoo_product/views/point_of_sale_view.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="pos_product_edit_price" model="ir.actions.act_window">
+        <field name="name">Products</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">product.template</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree</field>
+        <field name="context">{}</field>
+        <field name="search_view_id" ref="product.product_template_search_view"/>
+        <field name="view_id" eval="product_template_edit_price_tree_view"/>
+        <field name="help" type="html">
+          <p class="o_view_nocontent_smiling_face">
+            Create a new product
+          </p><p>
+            You must define a product for everything you purchase,
+            whether it's a physical product, a consumable or services.
+          </p>
+        </field>
+    </record>
+
+    <!-- menu item -->
+    <menuitem id="menu_pos_edit_price"
+              name="Edit Price"
+              parent="point_of_sale.menu_point_root"
+              sequence="100"
+              action="pos_product_edit_price"/>
+
+</odoo>

--- a/beesdoo_product/views/purchase_views.xml
+++ b/beesdoo_product/views/purchase_views.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="purchase_product_edit_price" model="ir.actions.act_window">
+        <field name="name">Products</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">product.template</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree</field>
+        <field name="context">{}</field>
+        <field name="search_view_id" ref="product.product_template_search_view"/>
+        <field name="view_id" eval="product_template_edit_price_tree_view"/>
+        <field name="help" type="html">
+          <p class="o_view_nocontent_smiling_face">
+            Create a new product
+          </p><p>
+            You must define a product for everything you purchase,
+            whether it's a physical product, a consumable or services.
+          </p>
+        </field>
+    </record>
+
+    <!-- menu item -->
+    <menuitem id="menu_purchase_edit_price"
+              name="Edit Price"
+              parent="purchase.menu_purchase_root"
+              sequence="100"
+              action="purchase_product_edit_price"/>
+
+</odoo>

--- a/beesdoo_product/views/sale_views.xml
+++ b/beesdoo_product/views/sale_views.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="sale_product_edit_price" model="ir.actions.act_window">
+        <field name="name">Products</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">product.template</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree</field>
+        <field name="context">{}</field>
+        <field name="search_view_id" ref="product.product_template_search_view"/>
+        <field name="view_id" eval="product_template_edit_price_tree_view"/>
+        <field name="help" type="html">
+          <p class="o_view_nocontent_smiling_face">
+            Create a new product
+          </p><p>
+            You must define a product for everything you purchase,
+            whether it's a physical product, a consumable or services.
+          </p>
+        </field>
+    </record>
+
+    <!-- menu item -->
+    <menuitem id="menu_sale_edit_price"
+              name="Edit Price"
+              parent="sale.sale_menu_root"
+              sequence="100"
+              action="sale_product_edit_price"/>
+
+</odoo>

--- a/beesdoo_product/wizard/__init__.py
+++ b/beesdoo_product/wizard/__init__.py
@@ -1,1 +1,2 @@
 from . import label_printing_utils
+from . import adapt_sales_price_wizard

--- a/beesdoo_product/wizard/adapt_sales_price_wizard.py
+++ b/beesdoo_product/wizard/adapt_sales_price_wizard.py
@@ -1,0 +1,19 @@
+from odoo import api, fields, models
+
+
+class AdaptSalesPriceWizard(models.TransientModel):
+    _name = "adapt.sales.price.wizard"
+    _description = "adapt.sales.price.wizard"
+
+    def _get_selected_products(self):
+        return self.env.context["active_ids"]
+
+    product_ids = fields.Many2many(
+        "product.template", default=_get_selected_products
+    )
+
+    @api.multi
+    def adapt_sales_price(self):
+        self.ensure_one()
+        for product in self.product_ids:
+            product.write({"list_price": product.suggested_price})

--- a/beesdoo_product/wizard/views/adapt_sales_price_wizard_view.xml
+++ b/beesdoo_product/wizard/views/adapt_sales_price_wizard_view.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="adapt_sales_price_wizard" model="ir.ui.view">
+        <field name="name">Adapt Sales Price Wizard</field>
+        <field name="model">adapt.sales.price.wizard</field>
+        <field name="arch" type="xml">
+            <form>
+                <field name="product_ids"/>
+                <footer>
+                    <button type="object"
+                            name="adapt_sales_price"
+                            string="Adapt Sales Price"
+                            class="oe_highlight"/>
+                    <button special="cancel" string="Cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+    <act_window name="Adapt Sales Price"
+                res_model="adapt.sales.price.wizard"
+                src_model="product.template"
+                view_mode="form"
+                view_id="adapt_sales_price_wizard"
+                target="new"
+                key2="client_action_multi"
+                id="beesdoo_product_pricelist_action_adapt_sales_price"
+    />
+</odoo>


### PR DESCRIPTION
## [Task](https://gestion.coopiteasy.be/web#id=5277&view_type=form&model=project.task)

Adds "Edit Price" submenu on Point Of Sale, Purchase and Sale modules.
The user lands on an editable List View with the following columns :

- Name (`name`)
- Main Seller (`main_seller_id`)
- Purchase Price (`purchase_price`)
- Purchase Unit of Measure (`uom_po_id`)
- Suggested Price (`suggested_price`)
- Sales Price (`list_price`)
- Unit of Measure (`uom_id`)

The only editable field is Purchase Price.

Through "Action > Adapt Sales Price", the user can, on the selected products, adapt the Sales Price according to the Suggested Price.