### PR TITLE
[FIX] beesdoo_product: default tree view unaltered

### DIFF
--- a/beesdoo_product/views/beesdoo_product.xml
+++ b/beesdoo_product/views/beesdoo_product.xml
@@ -89,6 +89,7 @@
     <record id="product_template_edit_price_tree_view" model="ir.ui.view">
         <field name="name">product.template.edit.price.tree</field>
         <field name="model">product.template</field>
+        <field name="priority" eval="100"/>
         <field name="arch" type="xml">
             <tree string="Product" editable="top" edit="true">
                 <field name="name" readonly="1"/>


### PR DESCRIPTION
add `priority` field:
> priority
  client programs can request views by id, or by (model, type).
  For the latter, all the views for the right type and model will be searched,
  and the one with the lowest priority number will be returned (it is the “default view”).