### PR TITLE
[12.0][FIX] Statut des coopérateurs travailleurs traduisibles

### DIFF
--- a/beesdoo_shift/models/cooperative_status.py
+++ b/beesdoo_shift/models/cooperative_status.py
@@ -45,14 +45,14 @@ class CooperativeStatus(models.Model):
 
     def _get_status(self):
         return [
-            ("ok", "Up to Date"),
-            ("holiday", "Holidays"),
-            ("alert", "Alerte"),
-            ("extension", "Extension"),
-            ("suspended", "Suspended"),
-            ("exempted", "Exempted"),
-            ("unsubscribed", "Unsubscribed"),
-            ("resigning", "Resigning"),
+            ("ok", _("Up to Date")),
+            ("holiday", _("Holidays")),
+            ("alert", _("Warning")),
+            ("extension", _("Extension")),
+            ("suspended", _("Suspended")),
+            ("exempted", _("Exempted")),
+            ("unsubscribed", _("Unsubscribed")),
+            ("resigning", _("Resigning")),
         ]
 
     today = fields.Date(


### PR DESCRIPTION
[task](https://gestion.coopiteasy.be/web#id=5899&view_type=form&model=project.task&action=475&active_id=160)


forget it
--- 

Problème: Le statut des coopérateur n'est pas traduisible, ce champ est _related_ vers `cooperative.status`  qui n'est pas non plus traduisible.

```py

class ResPartner(models.Model):
    _inherit = "res.partner"

    state = fields.Selection(
        related="cooperative_status_ids.status", 
        readonly=True,
        store=True
    )

class CooperativeStatus(models.Model):
    _name = "cooperative.status"

    def _get_status(self):
        statuses = [
            ("ok", "Up to Date"),
            ("holiday", "Holidays"),
            ("alert", "Warning"),
            ("extension", "Extension"),
            ("suspended", "Suspended"),
            ("exempted", "Exempted"),
            ("unsubscribed", "Unsubscribed"),
            ("resigning", "Resigning"),
        ]

    status = fields.Selection(
        selection=_get_status,
        compute="_compute_status",
        string="Cooperative Status",
        translate=True,
        store=True,
    )
```

Le champs n'est pas traduit car l'attribut du champs status est un _callable_. En mettant la liste des status en dur dans la définition du champs, le contenu du champs est correct.

En effet, dans `fields.py`, on a:

```py
class Selection(Field):
    ...
    def _description_selection(self, env):
        """ return the selection list (pairs (value, label)); labels are
            translated according to context language
        """
        selection = self.selection
        if isinstance(selection, pycompat.string_types):
            return getattr(env[self.model_name], selection)()
        if callable(selection):
            return selection(env[self.model_name])                              <---- retourne la valeur non traduite

        # translate selection labels
        if env.lang:
            name = "%s,%s" % (self.model_name, self.name)
            translate = partial(
                env['ir.translation']._get_source, name, 'selection', env.lang)
            return [(value, translate(label) if label else label) for value, label in selection]
        else:
            return selection
```

J'ai essayé le fix proposé en PR mais ce n'est pas suffisant car la liste des termes sources n'est pas à jour. Il faudrait trouver comment ajouter ces termes à l'update/init du module. Mais je m'arrête là car 

- j'ai déjà passé 2h+ sur cette tâche
- j'ai l'impression de m'enfoncer dans les arcanes d'odoo (c'est fun mais probablement overkill)

**Une solution plus simple?**
Je ne vois pas d'autres occurrences de _get_status dans notre code base. J'ai fait l'hypothèse que la fonction n'est pas là pour rien mais est-ce bien le cas? est-ce utilisé chez macavrac?). Est-ce qu'on se dit que c'était inutile et je mets la liste des status en dur? On peut toujours changer la liste des status en surchargeant la définition du champs...

Ou il y a autre chose de plus simple encore que je ne vois pas?