### PR TITLE
[FIX] beesdoo_shift: subscribed_shift_ids readonly

### DIFF
--- a/beesdoo_shift/models/res_partner.py
+++ b/beesdoo_shift/models/res_partner.py
@@ -61,7 +61,9 @@ class ResPartner(models.Model):
         readonly=True,
         store=True,
     )
-    subscribed_shift_ids = fields.Many2many("beesdoo.shift.template")
+    subscribed_shift_ids = fields.Many2many(
+        comodel_name="beesdoo.shift.template", readonly=True
+    )
 
     @api.depends("cooperative_status_ids")
     def _compute_can_shop(self):


### PR DESCRIPTION
[T3192 - Erreur quand on essaie de valider une timesheet](https://gestion.coopiteasy.be/web?#id=5894&view_type=form&model=project.task&action=479)

If the partner is subscribed directly through the form, the cooperative.status is not created. The user MUST go through the wizards.