### PR TITLE
[12.0] display available shift as week table

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 exclude: "^setup/|/static/lib/|/static/src/lib/"
 default_language_version:
-    python: python3
+    python: python3.5
 repos:
     -   repo: https://github.com/psf/black
         rev: 19.3b0

--- a/beesdoo_website_shift/controllers/main.py
+++ b/beesdoo_website_shift/controllers/main.py
@@ -322,7 +322,6 @@ class WebsiteShiftController(http.Controller):
         )
 
         # Get config
-        # irregular_shift_limit = request.website.irregular_shift_limit
         highlight_rule_pc = request.website.highlight_rule_pc
         hide_rule = request.website.hide_rule / 100.0
 

--- a/beesdoo_website_shift/controllers/main.py
+++ b/beesdoo_website_shift/controllers/main.py
@@ -325,18 +325,25 @@ class WebsiteShiftController(http.Controller):
         highlight_rule_pc = request.website.highlight_rule_pc
         hide_rule = request.website.hide_rule / 100.0
 
-        # Grouby task_template_id, will be arranged by task type in the
-        # grid.
-        groupby_iter = groupby(shifts, lambda s: s.task_template_id)
+        groupby_iter = groupby(
+            shifts,
+            lambda s: (s.task_template_id, s.start_time, s.task_type_id),
+        )
 
         displayed_shifts = []
-        for task_template, grouped_shifts in groupby_iter:
+        for keys, grouped_shifts in groupby_iter:
+            task_template, start_time, task_type = keys
             shift_list = list(grouped_shifts)
             # Compute available space
             free_space = len(shift_list)
             # Is the current user subscribed to this task_template
             is_subscribed = any(
-                shift.id in subscribed_shifts.ids for shift in shift_list
+                (
+                    sub_shift.task_template_id == task_template
+                    and sub_shift.start_time == start_time
+                    and sub_shift.task_type_id == task_type
+                )
+                for sub_shift in subscribed_shifts
             )
             # Check the necessary number of worker based on the
             # highlight_rule_pc

--- a/beesdoo_website_shift/controllers/shift_grid_utils.py
+++ b/beesdoo_website_shift/controllers/shift_grid_utils.py
@@ -1,0 +1,91 @@
+# Copyright 2017-2020 Coop IT Easy SCRLfs (http://coopiteasy.be)
+#   Robin Keunen <robin@coopiteasy.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from collections import namedtuple
+from datetime import date, datetime, timedelta
+from itertools import groupby
+from typing import Dict, Iterable, List, Tuple
+
+import pytz
+
+from odoo.http import request
+
+# Model used in the templates. Behaves like a tuple
+# but also allows accessing elements by name
+DisplayedShift = namedtuple(
+    "DisplayedShift",
+    ["shift", "free_space", "is_subscribed", "has_enough_workers"],
+)
+
+
+def _localize(timestamp: datetime) -> datetime:
+    tz_name = request.env.user.tz or pytz.utc
+    utc_timestamp = pytz.utc.localize(timestamp, is_dst=False)  # UTC = no DST
+    context_tz = pytz.timezone(tz_name)
+    return utc_timestamp.astimezone(context_tz)
+
+
+def _start_end_tuple(ds: DisplayedShift) -> Tuple[str, str]:
+    local_start = _localize(ds.shift.start_time)
+    local_end = _localize(ds.shift.end_time)
+    return local_start.strftime("%H:%M"), local_end.strftime("%H:%M")
+
+
+def _group_by_day(shifts: Iterable[DisplayedShift], monday: date) -> List:
+    groupby_iter = groupby(shifts, key=lambda ds: ds.shift.start_time.date())
+    shifts_by_day = {
+        # fixme can we have several shifts per time/date here? I'd say yes
+        day: list(grouped_shifts)
+        for day, grouped_shifts in groupby_iter
+    }
+
+    # fill the gaps
+    weekdays = (monday + timedelta(days=i) for i in range(7))
+    return [shifts_by_day.get(day, None) for day in weekdays]
+
+
+def _group_by_time(shifts: Iterable[DisplayedShift], monday: date) -> Dict:
+    groupby_iter = groupby(
+        sorted(shifts, key=_start_end_tuple), key=_start_end_tuple
+    )
+    shifts_by_time = [
+        ((start, end), _group_by_day(grouped_shifts, monday))
+        for (start, end), grouped_shifts in groupby_iter
+    ]
+    headers = [monday + timedelta(days=i) for i in range(7)]
+    return {"headers": headers, "rows": shifts_by_time}
+
+
+def _get_previous_monday(dshift: DisplayedShift) -> DisplayedShift:
+    start_time = dshift.shift.start_time.date()
+    return start_time + timedelta(days=-start_time.weekday())
+
+
+def build_shift_grid(shifts: List[DisplayedShift]) -> List:
+    """
+    Takes a list of shifts as arguments and builds a grid
+    to be displayed by available_shift_irregular_worker_grid.
+    The output looks like:
+    [(datetime.date(2021, 1, 18),  # week
+        {'headers': [datetime.date(2021, 1, 18), ]  # week days
+         'rows': [(('07:00', '09:15'),  # start and end time
+                   [DisplayedShift(  # shifts by day or None (7 columns)
+                        shift=beesdoo.shift.shift(11950,),
+                        free_space=1,
+                        is_subscribed=False,
+                        has_enough_workers=False)), *
+                    ], *
+                  ), ...
+                 ],
+        }), ...
+    """
+    # groupby only works on sorted sets.
+    groupby_iter = groupby(
+        sorted(shifts, key=_get_previous_monday), key=_get_previous_monday
+    )
+    shifts_by_week = [
+        (monday, _group_by_time(grouped_shifts, monday))
+        for monday, grouped_shifts in groupby_iter
+    ]
+    return sorted(shifts_by_week, key=lambda t: t[0])

--- a/beesdoo_website_shift/models/res_config.py
+++ b/beesdoo_website_shift/models/res_config.py
@@ -8,9 +8,6 @@ class WebsiteShiftConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
     # Irregular worker settings
-    irregular_shift_limit = fields.Integer(
-        related="website_id.irregular_shift_limit", readonly=False
-    )
     highlight_rule_pc = fields.Integer(
         related="website_id.highlight_rule_pc", readonly=False
     )

--- a/beesdoo_website_shift/models/website.py
+++ b/beesdoo_website_shift/models/website.py
@@ -8,9 +8,6 @@ class Website(models.Model):
     _inherit = "website"
 
     # Irregular worker settings
-    irregular_shift_limit = fields.Integer(
-        default=0, help="Maximum shift that will be shown"
-    )
     highlight_rule_pc = fields.Integer(
         string="Percentage threshold highlight rule",
         default=30,

--- a/beesdoo_website_shift/views/my_shift_website_templates.xml
+++ b/beesdoo_website_shift/views/my_shift_website_templates.xml
@@ -234,103 +234,124 @@
     </template>
 
     <template
-            id="available_shift_irregular_worker"
+            id="available_shift_irregular_worker_card"
             name="Available Shift for Irregular Worker"
     >
+        <t t-set="shift" t-value="displayed_shift.shift"/>
+        <t t-set="count" t-value="displayed_shift.free_space"/>
+        <t t-set="is_subscribed" t-value="displayed_shift.is_subscribed"/>
+        <t t-set="has_enough_workers"
+           t-value="displayed_shift.has_enough_workers"/>
+        <t t-set="highlight_class"
+           t-value="'panel-warning' if not has_enough_workers else 'panel-default'"/>
 
-        <t t-foreach="shift_templates" t-as="shift_count_subscribed">
-            <t t-set="shift" t-value="shift_count_subscribed[0]"/>
-            <t t-set="count" t-value="shift_count_subscribed[1]"/>
-            <t t-set="is_subscribed" t-value="shift_count_subscribed[2]"/>
-            <t t-set="has_enough_workers" t-value="shift_count_subscribed[3]"/>
-            <t t-set="highlight_class"
-               t-value="'panel-warning' if not has_enough_workers else 'panel-default'"/>
-            <div t-att-class="'card mb-4 %s' % highlight_class">
-                <div t-att-class="'card-header %s clearfix' % highlight_header_class">
-                    <div class="pull-left">
-                        <span t-field="shift.start_time"/>
-                        -
-                        <span t-field="shift.end_time"
-                              t-options='{"format": "HH:mm"}'/>
-                    </div>
-                    <div class="badge badge-secondary pull-right"
-                         t-if="count > 0">
-                        <t t-esc="count"/>
-                        space(s)
-                    </div>
-                    <div class="badge badge-secondary pull-right"
-                         t-if="count == 0">
-                        full
-                    </div>
-                </div>
-                <div class="card-body clearfix">
-                    <t t-esc="shift.task_type_id.name"/>
-                    <div class="badge badge-success pull-right"
-                         t-if="is_subscribed">
-                        Subscribed
-                    </div>
-                    <button
-                            type="button"
-                            class="btn btn-default btn-sm pull-right"
-                            data-toggle="modal"
-                            t-att-data-target="'#subscribe-shift-%s' % shift.id"
-                            t-if="irregular_enable_sign_up and not is_subscribed"
-                    >
-                        <span class="fa fa-user-plus" aria-hidden="true"></span>
-                        Subscribe
-                    </button>
-                </div>
+        <div class="card highlight_class">
+            <div class="center m-1 font-weight-bold"
+                 t-esc="shift.task_type_id.name"/>
+            <div class="badge badge-secondary m-1"
+                 t-if="count > 0">
+                <t t-esc="count"/>
+                spot(s)
             </div>
+            <div class="badge badge-secondary m-1"
+                 t-if="count == 0">
+                full
+            </div>
+            <div class="badge badge-secondary m-1"
+                 t-if="is_subscribed">
+                Subscribed
+            </div>
+            <button
+                    type="button"
+                    class="btn btn-default btn-sm m-1"
+                    data-toggle="modal"
+                    t-att-data-target="'#subscribe-shift-%s' % shift.id"
+                    t-if="irregular_enable_sign_up and not is_subscribed"
+            >
+                <span class="fa fa-user-plus" aria-hidden="true"></span>
+                Subscribe
+            </button>
+        </div>
 
-            <!-- Subscribe check -->
-            <t t-foreach="shift_templates" t-as="shift_count_subscribed">
-                <t t-set="shift" t-value="shift_count_subscribed[0]"/>
-                <t t-set="count" t-value="shift_count_subscribed[1]"/>
-                <t t-set="is_subscribed" t-value="shift_count_subscribed[2]"/>
-                <div class="modal fade"
-                     t-att-id="'subscribe-shift-%s' % shift.id" tabindex="-1"
-                     role="dialog"
-                     t-att-aria-labelledby="'subscribe-shift-%s-label' % shift.id">
-                    <div class="modal-dialog" role="document">
-                        <div class="modal-content">
-                            <div class="modal-header">
-                                <button type="button" class="close"
-                                        data-dismiss="modal" aria-label="Close">
-                                    <span aria-hidden="true">×</span>
-                                </button>
-                                <h4 class="modal-title"
-                                    t-att-id="'subscribe-shift-%s-label' % shift.id">
-                                    Please confirm subscription
-                                </h4>
-                            </div>
-                            <div class="modal-body">
-                                <span t-field="shift.start_time"/>
-                                -
-                                <span t-field="shift.end_time"
-                                      t-options='{"format": "HH:mm"}'/>
-                                <br/>
-                                <t t-esc="shift.task_type_id.name"/>
-                                <br/>
-                                <t t-esc="count"/>
-                                available space(s)
-                            </div>
-                            <div class="modal-footer">
-                                <button type="button" class="btn btn-default"
-                                        data-dismiss="modal">Close
-                                </button>
-                                <a class="btn btn-primary"
-                                   t-if="irregular_enable_sign_up"
-                                   t-att-href="'/shift/%s/subscribe?nexturl=%s' % (shift.id, nexturl)">
-                                    Subscribe
-                                </a>
-                            </div>
-                        </div>
+    </template>
+
+    <template id="available_shift_irregular_worker_row"
+              name="Available Shifts by Week Row">
+        <t t-set="headers" t-value="shift_by_week['headers']"/>
+        <t t-set="rows" t-value="shift_by_week['rows']"/>
+        <div class="table-responsive">
+            <table class="table text-center">
+                <thead>
+                    <th style="width: 9%"/>
+                    <t t-foreach="headers" t-as="header">
+                        <th style="width: 13%"
+                            t-esc="header.strftime('%d/%m')"/>
+                    </t>
+                </thead>
+                <tbody>
+                    <t t-foreach="rows" t-as="shift_row">
+                        <t t-set="start_time"
+                           t-value="shift_row[0][0]"/>
+                        <t t-set="end_time"
+                           t-value="shift_row[0][1]"/>
+                        <tr>
+                            <td class="text-center align-middle">
+                                <div>
+                                    <div t-esc="start_time"/>
+                                    <div>-</div>
+                                    <div t-esc="end_time"/>
+                                </div>
+                            </td>
+                            <t t-foreach="shift_row[1]" t-as="shift_by_day">
+                                <td class="align-middle">
+                                    <t t-if="shift_by_day">
+                                        <t t-foreach="shift_by_day"
+                                           t-as="shift">
+                                            <t t-call="beesdoo_website_shift.available_shift_irregular_worker_card">
+                                                <t t-set="displayed_shift"
+                                                   t-value="shift"/>
+                                            </t>
+                                        </t>
+                                    </t>
+                                </td>
+                            </t>
+                        </tr>
+                    </t>
+                </tbody>
+            </table>
+        </div>
+    </template>
+
+    <template id="available_shift_irregular_worker_grid"
+              name="Available Shifts for Irregular Worker">
+        <!-- Renders week planning of schema:
+        [(datetime.date(2021, 1, 18),  # week
+            {'headers': [datetime.date(2021, 1, 18), ]  # week days
+             'rows': [(('07:00', '09:15'),  # start and end time
+                       [DisplayedShift(  # shifts by day or None (7 columns)
+                            shift=beesdoo.shift.shift(11950,),
+                            free_space=1,
+                            is_subscribed=False,
+                            has_enough_workers=False)), *
+                        ], *
+                      ), ...
+                     ],
+            }), ...
+        ]
+        -->
+        <div>
+            <t t-foreach="shift_weeks" t-as="shift_week_tuple">
+                <div class="card mb-2">
+                    <t t-set="week" t-value="shift_week_tuple[0]"/>
+                    <div class="card-body p-0">
+                        <t t-call="beesdoo_website_shift.available_shift_irregular_worker_row">
+                            <t t-set="shift_by_week"
+                               t-value="shift_week_tuple[1]"/>
+                        </t>
                     </div>
                 </div>
             </t>
-
-        </t>
-
+        </div>
     </template>
 
     <!-- Help Texts -->
@@ -775,7 +796,7 @@
                             </div>
                         </div>
 
-                        <t t-call="beesdoo_website_shift.available_shift_irregular_worker"/>
+                        <t t-call="beesdoo_website_shift.available_shift_irregular_worker_grid"/>
 
                         <t t-call="beesdoo_website_shift.my_shift_past_shifts"/>
 

--- a/beesdoo_website_shift/views/my_shift_website_templates.xml
+++ b/beesdoo_website_shift/views/my_shift_website_templates.xml
@@ -273,6 +273,47 @@
             </button>
         </div>
 
+        <!-- Subscribe modals -->
+        <div class="modal fade"
+             t-att-id="'subscribe-shift-%s' % shift.id" tabindex="-1"
+             role="dialog"
+             t-att-aria-labelledby="'subscribe-shift-%s-label' % shift.id">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close"
+                                data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">×</span>
+                        </button>
+                        <h4 class="modal-title"
+                            t-att-id="'subscribe-shift-%s-label' % shift.id">
+                            Please confirm subscription
+                        </h4>
+                    </div>
+                    <div class="modal-body">
+                        <span t-field="shift.start_time"/>
+                        -
+                        <span t-field="shift.end_time"
+                              t-options='{"format": "HH:mm"}'/>
+                        <br/>
+                        <t t-esc="shift.task_type_id.name"/>
+                        <br/>
+                        <t t-esc="count"/>
+                        available space(s)
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-default"
+                                data-dismiss="modal">Close
+                        </button>
+                        <a class="btn btn-primary"
+                           t-if="irregular_enable_sign_up"
+                           t-att-href="'/shift/%s/subscribe?nexturl=%s' % (shift.id, nexturl)">
+                            Subscribe
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
     </template>
 
     <template id="available_shift_irregular_worker_row"

--- a/beesdoo_website_shift/views/my_shift_website_templates.xml
+++ b/beesdoo_website_shift/views/my_shift_website_templates.xml
@@ -243,9 +243,9 @@
         <t t-set="has_enough_workers"
            t-value="displayed_shift.has_enough_workers"/>
         <t t-set="highlight_class"
-           t-value="'panel-warning' if not has_enough_workers else 'panel-default'"/>
+           t-value="'bg-warning' if not has_enough_workers else 'bg-light'"/>
 
-        <div class="card highlight_class">
+        <div t-att-class="'card %s' % highlight_class">
             <div class="center m-1 font-weight-bold"
                  t-esc="shift.task_type_id.name"/>
             <div class="badge badge-secondary m-1"

--- a/beesdoo_website_shift/views/res_config_views.xml
+++ b/beesdoo_website_shift/views/res_config_views.xml
@@ -13,18 +13,6 @@
                 <h2>Shift: Irregular Worker</h2>
                 <div class="row mt16 o_settings_container"
                      id="shift_irregular_settings">
-                    <div id="irregular_shift_limit_settings"
-                         class="col-12 col-md-6 o_setting_box">
-                        <div class="o_setting_right_pane">
-                            <label for="irregular_shift_limit"/>
-                            <span class="fa fa-lg fa-globe"
-                                  title="Values set here are website-specific."
-                                  groups="website.group_multi_website"/>
-                            <div class="mt8">
-                                <field name="irregular_shift_limit"/>
-                            </div>
-                        </div>
-                    </div>
                     <div id="highlight_rule_pc_settings"
                          class="col-12 col-md-6 o_setting_box">
                         <div class="o_setting_right_pane">

--- a/beesdoo_website_shift/views/shift_website_templates.xml
+++ b/beesdoo_website_shift/views/shift_website_templates.xml
@@ -149,10 +149,8 @@
 
                 <div class="container mb64">
                     <div class="row mt4 justify-content-center">
-                        <div class="col-12 col-lg-6">
-
-                            <t t-call="beesdoo_website_shift.available_shift_irregular_worker"/>
-
+                        <div class="col-12 col-lg-12">
+                            <t t-call="beesdoo_website_shift.available_shift_irregular_worker_grid"/>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
[T2816 - SPP - Afficher shifts en grille horaire et possibilité de s'inscrire](https://gestion.coopiteasy.be/web?#id=5518&view_type=form&model=project.task&action=479)

**Before** In `my/shift` and `shift_irregular_worker` pages are displayed in a long long list.

**After** the shifts are displayed along a week calendar like this

![Screenshot 2021-01-20 at 16 26 52](https://user-images.githubusercontent.com/3082119/105196832-5197cb80-5b3c-11eb-8995-70f1d4687045.png)

- I removed the configuration `irregular_shift_limit`  which was no longer relevant
- the grid is prepared in the python controller and displayed in the qweb
- I simplified the computation of shifts to display by only grouping by shift template. The shifts are grouped by time and template later during  the grid creation.
- I used namedtuple DisplayedShift (behaves like a tuple but also allows accessing elements by name) to simplify the code and qweb
- I used type hints to facilitate the grid creation
  - because I got confused
  - because I wanted to try it