### PR TITLE
[IMP] beesdoo_shift: unique status term for cooperative status

### DIFF
--- a/beesdoo_shift/README.rst
+++ b/beesdoo_shift/README.rst
@@ -26,6 +26,20 @@ Generate and manage shifts for cooperators.
 .. contents::
    :local:
 
+Configuration
+=============
+
+- Translate cooperative status selection field, the terms to translate are:
+
+  - shift_status_up_to_date,
+  - shift_status_holidays,
+  - shift_status_warning,
+  - shift_status_extension,
+  - shift_status_suspended,
+  - shift_status_exempted,
+  - shift_status_unsubscribed,
+  - shift_status_resigning.
+
 Bug Tracker
 ===========
 

--- a/beesdoo_shift/models/cooperative_status.py
+++ b/beesdoo_shift/models/cooperative_status.py
@@ -44,15 +44,20 @@ class CooperativeStatus(models.Model):
     _period = 28
 
     def _get_status(self):
+        # since the terms of these status are translated as "code" type
+        # if they are already translated elsewhere, it won't be possible
+        # to translate them to a specific status.
+        # Hence these unique terms that have to be translated at module
+        # configuration.
         return [
-            ("ok", _("Up to Date")),
-            ("holiday", _("Holidays")),
-            ("alert", _("Warning")),
-            ("extension", _("Extension")),
-            ("suspended", _("Suspended")),
-            ("exempted", _("Exempted")),
-            ("unsubscribed", _("Unsubscribed")),
-            ("resigning", _("Resigning")),
+            ("ok", _("shift_status_up_to_date")),
+            ("holiday", _("shift_status_holidays")),
+            ("alert", _("shift_status_warning")),
+            ("extension", _("shift_status_extension")),
+            ("suspended", _("shift_status_suspended")),
+            ("exempted", _("shift_status_exempted")),
+            ("unsubscribed", _("shift_status_unsubscribed")),
+            ("resigning", _("shift_status_resigning")),
         ]
 
     today = fields.Date(

--- a/beesdoo_shift/readme/CONFIGURE.rst
+++ b/beesdoo_shift/readme/CONFIGURE.rst
@@ -1,0 +1,10 @@
+- Translate cooperative status selection field, the terms to translate are:
+
+  - shift_status_up_to_date,
+  - shift_status_holidays,
+  - shift_status_warning,
+  - shift_status_extension,
+  - shift_status_suspended,
+  - shift_status_exempted,
+  - shift_status_unsubscribed,
+  - shift_status_resigning.

--- a/beesdoo_shift/static/description/index.html
+++ b/beesdoo_shift/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Beescoop Shift Management</title>
 <style type="text/css">
 
@@ -372,17 +372,34 @@ ul.auto-toc {
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#bug-tracker" id="id1">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id2">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id3">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id4">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id5">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="id1">Configuration</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id2">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id3">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id4">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id5">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id6">Maintainers</a></li>
+</ul>
+</li>
+</ul>
+</div>
+<div class="section" id="configuration">
+<h1><a class="toc-backref" href="#id1">Configuration</a></h1>
+<ul class="simple">
+<li>Translate cooperative status selection field, the terms to translate are:<ul>
+<li>shift_status_up_to_date,</li>
+<li>shift_status_holidays,</li>
+<li>shift_status_warning,</li>
+<li>shift_status_extension,</li>
+<li>shift_status_suspended,</li>
+<li>shift_status_exempted,</li>
+<li>shift_status_unsubscribed,</li>
+<li>shift_status_resigning.</li>
 </ul>
 </li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id1">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/beescoop/obeesdoo/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -390,9 +407,9 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id2">Credits</a></h1>
+<h1><a class="toc-backref" href="#id3">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id3">Authors</a></h2>
+<h2><a class="toc-backref" href="#id4">Authors</a></h2>
 <ul class="simple">
 <li>Thibault Francois</li>
 <li>Elouan Le Bars</li>
@@ -400,14 +417,14 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id4">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id5">Contributors</a></h2>
 <ul class="simple">
 <li>Beescoop - Cellule IT</li>
 <li>Coop IT Easy SCRLfs</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id5">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id6">Maintainers</a></h2>
 <p>This module is part of the <a class="reference external" href="https://github.com/beescoop/obeesdoo/tree/12.0/beesdoo_shift">beescoop/obeesdoo</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>


### PR DESCRIPTION
[T3381 - Impossible de trouver le terme source pour "Avertissement" (statut Alerte)](https://gestion.coopiteasy.be/web#id=6083&view_type=form&model=project.task)

Since the terms of these status are translated as "code" type          if they are already translated elsewhere, it won't be possible         to translate them to a specific status.

Hence these unique terms that have to be translated at module         configuration.