### PR TITLE
[12.0] beesdoo_[shift | worker_status]: cooperative status control order

### DIFF
--- a/beesdoo_shift/models/cooperative_status.py
+++ b/beesdoo_shift/models/cooperative_status.py
@@ -51,12 +51,12 @@ class CooperativeStatus(models.Model):
         # configuration.
         return [
             ("ok", _("shift_status_up_to_date")),
-            ("holiday", _("shift_status_holidays")),
             ("alert", _("shift_status_warning")),
-            ("extension", _("shift_status_extension")),
             ("suspended", _("shift_status_suspended")),
-            ("exempted", _("shift_status_exempted")),
+            ("extension", _("shift_status_extension")),
             ("unsubscribed", _("shift_status_unsubscribed")),
+            ("exempted", _("shift_status_exempted")),
+            ("holiday", _("shift_status_holidays")),
             ("resigning", _("shift_status_resigning")),
         ]
 

--- a/beesdoo_worker_status/models/cooperative_status.py
+++ b/beesdoo_worker_status/models/cooperative_status.py
@@ -158,10 +158,18 @@ class CooperativeStatus(models.Model):
         ok = self.sr >= 0 and self.sc >= 0
         grace_delay = grace_delay + self.time_extension
 
-        if (self.sr + self.sc) <= counter_unsubscribe or self.unsubscribed:
-            return "unsubscribed"
-        # Check if exempted. Exempt end date is not required.
+        # check `holiday`
         if (
+            self.holiday_start_time
+            and self.holiday_end_time
+            and self.today >= self.holiday_start_time
+            and self.today <= self.holiday_end_time
+        ):
+            return "holiday"
+
+        # check `exempted`.
+        # Exempt end date is not required.
+        elif (
             # Start and end are defined
             self.temporary_exempt_start_date
             and self.temporary_exempt_end_date
@@ -175,9 +183,10 @@ class CooperativeStatus(models.Model):
         ):
             return "exempted"
 
+        # check `extension`
         # Transition to alert sr < 0 or stay in alert sr < 0 or sc < 0 and
         # thus alert time is defined
-        if (
+        elif (
             not ok
             and self.alert_start_time
             and self.extension_start_time
@@ -186,32 +195,29 @@ class CooperativeStatus(models.Model):
         ):
             return "extension"
 
-        if (
+        # check `unsubscribed`
+        elif (self.sr + self.sc) <= counter_unsubscribe or self.unsubscribed:
+            return "unsubscribed"
+
+        # check `suspended`
+        elif (
             not ok
             and self.alert_start_time
             and self.extension_start_time
             and self.today
             > add_days_delta(self.extension_start_time, grace_delay)
-        ):
-            return "suspended"
-
-        if (
+        ) or (
             not ok
             and self.alert_start_time
             and self.today > add_days_delta(self.alert_start_time, alert_delay)
         ):
             return "suspended"
 
-        if (self.sr < 0) or (not ok and self.alert_start_time):
+        # check `alert`
+        elif (self.sr < 0) or (not ok and self.alert_start_time):
             return "alert"
 
-        if (
-            self.holiday_start_time
-            and self.holiday_end_time
-            and self.today >= self.holiday_start_time
-            and self.today <= self.holiday_end_time
-        ):
-            return "holiday"
+        # check `ok`
         elif ok or (not self.alert_start_time and self.sr >= 0):
             return "ok"
 
@@ -232,22 +238,33 @@ class CooperativeStatus(models.Model):
         )
         ok = self.sr >= 0
         grace_delay = grace_delay + self.time_extension
-        if self.sr <= counter_unsubscribe or self.unsubscribed:
-            return "unsubscribed"
-        # Check if exempted. Exempt end date is not required.
+
+        # check `holiday`
+        if (
+            self.holiday_start_time
+            and self.holiday_end_time
+            and self.today >= self.holiday_start_time
+            and self.today <= self.holiday_end_time
+        ):
+            return "holiday"
+
+        # check `exempted`
+        # Exempt end date is not required.
         elif (
-            # Start and end are defined
-            self.temporary_exempt_start_date
-            and self.temporary_exempt_end_date
-            and self.today >= self.temporary_exempt_start_date
-            and self.today <= self.temporary_exempt_end_date
+             # Start and end are defined
+             self.temporary_exempt_start_date
+             and self.temporary_exempt_end_date
+             and self.today >= self.temporary_exempt_start_date
+             and self.today <= self.temporary_exempt_end_date
         ) or (
-            # Only start is defined
-            self.temporary_exempt_start_date
-            and not self.temporary_exempt_end_date
-            and self.today >= self.temporary_exempt_start_date
+             # Only start is defined
+             self.temporary_exempt_start_date
+             and not self.temporary_exempt_end_date
+             and self.today >= self.temporary_exempt_start_date
         ):
             return "exempted"
+
+        # check `extension`
         # Transition to alert sr < 0 or stay in alert sr < 0 or sc < 0 and
         # thus alert time is defined
         elif (
@@ -258,30 +275,29 @@ class CooperativeStatus(models.Model):
             <= add_days_delta(self.extension_start_time, grace_delay)
         ):
             return "extension"
+
+        # check `unsubscribed`
+        elif self.sr <= counter_unsubscribe or self.unsubscribed:
+            return "unsubscribed"
+
+        # check `suspended`
         elif (
             not ok
             and self.alert_start_time
             and self.extension_start_time
             and self.today
             > add_days_delta(self.extension_start_time, grace_delay)
-        ):
-            return "suspended"
-        elif (
+        ) or (
             not ok
             and self.alert_start_time
             and self.today > add_days_delta(self.alert_start_time, alert_delay)
         ):
             return "suspended"
+        # check `alert`
         elif (self.sr < 0) or (not ok and self.alert_start_time):
             return "alert"
 
-        elif (
-            self.holiday_start_time
-            and self.holiday_end_time
-            and self.today >= self.holiday_start_time
-            and self.today <= self.holiday_end_time
-        ):
-            return "holiday"
+        # check `ok`
         elif ok or (not self.alert_start_time and self.sr >= 0):
             return "ok"
 


### PR DESCRIPTION
# [Task](https://gestion.coopiteasy.be/web#id=6741&view_type=form&model=project.task)

Control must be made in the following order : 
- Contrôle des Congés/Pause (`holiday`)
- Exemption (`exempted`)
- Extension (`extension`)
- Gelé (`unsubscribed`)
- Suspendu/Alerte rouge (`suspended`)
- Alerte (`alert`)
- A jour (`ok`) 