### PR TITLE
[12.0][ADD] beesdoo_shift: parameters to _cron_send_weekly_emails

### DIFF
--- a/beesdoo_shift/README.rst
+++ b/beesdoo_shift/README.rst
@@ -40,6 +40,10 @@ Configuration
   - shift_status_unsubscribed,
   - shift_status_resigning.
 
+- Configure "Send weekly shift summary" cron:
+
+  - Its interval number (default = 7) should be consistent with notice (default = 1) and period (default = 7).
+
 Bug Tracker
 ===========
 

--- a/beesdoo_shift/data/cron.xml
+++ b/beesdoo_shift/data/cron.xml
@@ -38,7 +38,7 @@
             <field name="name">Send weekly shift summary</field>
             <field name="model_id" ref="model_beesdoo_shift_shift" />
             <field name="state">code</field>
-            <field name="code">model._cron_send_weekly_emails()</field>
+            <field name="code">model._cron_send_weekly_emails(notice=1, period=7)</field>
             <field name="interval_number">7</field>
             <field name="interval_type">days</field>
             <field name="numbercall">-1</field>

--- a/beesdoo_shift/models/task.py
+++ b/beesdoo_shift/models/task.py
@@ -310,18 +310,18 @@ class Task(models.Model):
             self._set_revert_info(data, status)
 
     @api.model
-    def _cron_send_weekly_emails(self):
+    def _cron_send_weekly_emails(self, notice=1, period=7):
         """
         Send a summary email for all workers
-        if they have a shift planned during the week.
+        if they have a shift planned between `notice` and `notice + period` days.
         """
         tasks = self.env["beesdoo.shift.shift"]
         shift_summary_mail_template = self.env.ref(
             "beesdoo_shift.email_template_shift_summary", False
         )
 
-        start_time = datetime.now() + timedelta(days=1)
-        end_time = datetime.now() + timedelta(days=7)
+        start_time = datetime.now() + timedelta(days=notice)
+        end_time = datetime.now() + timedelta(days=notice + period)
 
         confirmed_tasks = tasks.search(
             [

--- a/beesdoo_shift/readme/CONFIGURE.rst
+++ b/beesdoo_shift/readme/CONFIGURE.rst
@@ -8,3 +8,7 @@
   - shift_status_exempted,
   - shift_status_unsubscribed,
   - shift_status_resigning.
+
+- Configure "Send weekly shift summary" cron:
+
+  - Its interval number (default = 7) should be consistent with notice (default = 1) and period (default = 7).

--- a/beesdoo_shift/static/description/index.html
+++ b/beesdoo_shift/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
 <title>Beescoop Shift Management</title>
 <style type="text/css">
 
@@ -394,6 +394,10 @@ ul.auto-toc {
 <li>shift_status_exempted,</li>
 <li>shift_status_unsubscribed,</li>
 <li>shift_status_resigning.</li>
+</ul>
+</li>
+<li>Configure “Send weekly shift summary” cron:<ul>
+<li>Its interval number (default = 7) should be consistent with notice (default = 1) and period (default = 7).</li>
 </ul>
 </li>
 </ul>


### PR DESCRIPTION
## [Task](https://gestion.coopiteasy.be/web#id=6478&view_type=form&model=project.task&action=479)

This PR adds the following parameters to both record `ir_cron_send_weekly_emails` and its method `_cron_send_weekly_emails`:
- `notice=1`
- `period=7`

As the record `ir_cron_send_weekly_emails` is in a `<data noupdate="1">` element, administrators need to first delete the record, then update the module in order to recreate it (if `beesdoo_shift` is already installed on a database)

However, with the default values, this modification is backward compatible and will not raise any error if the delete-the-record-then-update-the-module action is not done.

Special thanks to @Yo-Be for coming up with that solution