### PR TITLE
[12.0][FIX] suggested price computations

### DIFF
--- a/beesdoo_product/models/beesdoo_product.py
+++ b/beesdoo_product/models/beesdoo_product.py
@@ -38,7 +38,9 @@ class BeesdooProductHazard(models.Model):
 class BeesdooProduct(models.Model):
     _inherit = "product.template"
 
-    eco_label = fields.Many2one("beesdoo.product.label", domain=[("type", "=", "eco")])
+    eco_label = fields.Many2one(
+        "beesdoo.product.label", domain=[("type", "=", "eco")]
+    )
     local_label = fields.Many2one(
         "beesdoo.product.label", domain=[("type", "=", "local")]
     )
@@ -71,7 +73,9 @@ class BeesdooProduct(models.Model):
 
     display_unit = fields.Many2one("uom.uom")
     default_reference_unit = fields.Many2one("uom.uom")
-    display_weight = fields.Float(compute="_compute_display_weight", store=True)
+    display_weight = fields.Float(
+        compute="_compute_display_weight", store=True
+    )
 
     total_with_vat = fields.Float(
         compute="_compute_total",
@@ -104,14 +108,18 @@ class BeesdooProduct(models.Model):
     )
 
     deadline_for_sale = fields.Integer(string="Deadline for sale(days)")
-    deadline_for_consumption = fields.Integer(string="Deadline for consumption(days)")
+    deadline_for_consumption = fields.Integer(
+        string="Deadline for consumption(days)"
+    )
     ingredients = fields.Char(string="Ingredient")
     scale_label_info_1 = fields.Char(string="Scale lable info 1")
     scale_label_info_2 = fields.Char(string="Scale lable info 2")
     scale_sale_unit = fields.Char(
         compute="_compute_scale_sale_uom", string="Scale sale unit", store=True
     )
-    scale_category = fields.Many2one("beesdoo.scale.category", string="Scale Category")
+    scale_category = fields.Many2one(
+        "beesdoo.scale.category", string="Scale Category"
+    )
     scale_category_code = fields.Integer(
         related="scale_category.code",
         string="Scale category code",
@@ -167,22 +175,31 @@ class BeesdooProduct(models.Model):
                     ]
                 )[0]
                 default_code = seq_internal_code.next_by_id()
-                while self.search_count([("default_code", "=", default_code)]) > 1:
+                while (
+                    self.search_count([("default_code", "=", default_code)])
+                    > 1
+                ):
                     default_code = seq_internal_code.next_by_id()
                 self.default_code = default_code
             ean = "02" + self.default_code[0:5] + "000000"
-            bc = ean[0:12] + str(self.env["barcode.nomenclature"].ean_checksum(ean))
+            bc = ean[0:12] + str(
+                self.env["barcode.nomenclature"].ean_checksum(ean)
+            )
         else:
             rule = self.env["barcode.rule"].search(
                 [("name", "=", "Beescoop Product Barcodes")]
             )[0]
             size = 13 - len(rule.pattern)
             ean = rule.pattern + str(uuid.uuid4().fields[-1])[:size]
-            bc = ean[0:12] + str(self.env["barcode.nomenclature"].ean_checksum(ean))
+            bc = ean[0:12] + str(
+                self.env["barcode.nomenclature"].ean_checksum(ean)
+            )
             # Make sure there is no other active member with the same barcode
             while self.search_count([("barcode", "=", bc)]) > 1:
                 ean = rule.pattern + str(uuid.uuid4().fields[-1])[:size]
-                bc = ean[0:12] + str(self.env["barcode.nomenclature"].ean_checksum(ean))
+                bc = ean[0:12] + str(
+                    self.env["barcode.nomenclature"].ean_checksum(ean)
+                )
         _logger.info("barcode :", bc)
         self.barcode = bc
 
@@ -193,7 +210,9 @@ class BeesdooProduct(models.Model):
             # Calcule le vendeur associé qui a la date de début la plus récente
             # et plus petite qu’aujourd’hui
             sellers_ids = product._get_main_supplier_info()
-            product.main_seller_id = sellers_ids and sellers_ids[0].name or False
+            product.main_seller_id = (
+                sellers_ids and sellers_ids[0].name or False
+            )
 
     @api.multi
     @api.depends(
@@ -225,7 +244,9 @@ class BeesdooProduct(models.Model):
                 product.total_with_vat = product.list_price
                 product.total_deposit = sum(
                     [
-                        tax._compute_amount(product.list_price, product.list_price)
+                        tax._compute_amount(
+                            product.list_price, product.list_price
+                        )
                         for tax in product.taxes_id
                         if tax.tax_group_id == consignes_group
                     ]
@@ -233,7 +254,9 @@ class BeesdooProduct(models.Model):
             else:
                 tax_amount_sum = sum(
                     [
-                        tax._compute_amount(product.list_price, product.list_price)
+                        tax._compute_amount(
+                            product.list_price, product.list_price
+                        )
                         for tax in product.taxes_id
                         if tax.tax_group_id != consignes_group
                     ]
@@ -249,13 +272,17 @@ class BeesdooProduct(models.Model):
             )
 
             if product.display_weight > 0:
-                product.total_with_vat_by_unit = product.total_with_vat / product.weight
+                product.total_with_vat_by_unit = (
+                    product.total_with_vat / product.weight
+                )
 
     @api.multi
     @api.depends("weight", "display_unit")
     def _compute_display_weight(self):
         for product in self:
-            product.display_weight = product.weight * product.display_unit.factor
+            product.display_weight = (
+                product.weight * product.display_unit.factor
+            )
 
     @api.multi
     @api.constrains("display_unit", "default_reference_unit")
@@ -298,7 +325,9 @@ class BeesdooProduct(models.Model):
                 profit_margin_product_category = suppliers[
                     0
                 ].product_tmpl_id.categ_id.profit_margin
-                profit_margin = profit_margin_supplier or profit_margin_product_category
+                profit_margin = (
+                    profit_margin_supplier or profit_margin_product_category
+                )
                 profit_margin_factor = (
                     1 / (1 - profit_margin / 100)
                     if suggested_price_reference == "sale_price"
@@ -312,7 +341,9 @@ class BeesdooProduct(models.Model):
                     * profit_margin_factor
                 )
 
-                if suppliers[0].product_tmpl_id.categ_id.should_round_suggested_price:
+                if suppliers[
+                    0
+                ].product_tmpl_id.categ_id.should_round_suggested_price:
                     product.suggested_price = round_5c(product.suggested_price)
 
     @api.multi
@@ -340,7 +371,9 @@ class BeesdooProduct(models.Model):
     def create_request_label_printing_wizard(self):
         context = {"active_ids": self.ids}
         self.env["label.printing.wizard"].with_context(context).create({})
-        print_request_view = self.env.ref("beesdoo_product.printing_label_request_wizard")
+        print_request_view = self.env.ref(
+            "beesdoo_product.printing_label_request_wizard"
+        )
         return {
             "type": "ir.actions.act_window",
             "res_model": "label.printing.wizard",

--- a/beesdoo_product/models/beesdoo_product.py
+++ b/beesdoo_product/models/beesdoo_product.py
@@ -300,7 +300,14 @@ class BeesdooProduct(models.Model):
                 )
 
     @api.multi
-    @api.depends("seller_ids", "supplier_taxes_id", "taxes_id")
+    @api.depends(
+        "seller_ids",
+        "supplier_taxes_id",
+        "taxes_id",
+        "uom_id",
+        "uom_po_id",
+        "categ_id.should_round_suggested_price",
+    )
     def _compute_cost(self):
         suggested_price_reference = (
             self.env["ir.config_parameter"]

--- a/beesdoo_product/models/beesdoo_product.py
+++ b/beesdoo_product/models/beesdoo_product.py
@@ -299,6 +299,9 @@ class BeesdooProduct(models.Model):
                     )
                 )
 
+    # fixme rename to _compute_suggested_price
+    # fixme move to new module product_suggested_price
+    #  or sale_suggested_price
     @api.multi
     @api.depends(
         "seller_ids",
@@ -341,9 +344,13 @@ class BeesdooProduct(models.Model):
                     else (1 + profit_margin / 100)
                 )
 
+                # price of purchase is given for uom_po_id
+                #   suggested *sale* price must be adapted to uom_id
+                uom_factor = product.uom_po_id.factor / product.uom_id.factor
+
                 product.suggested_price = (
                     price
-                    * product.uom_po_id.factor
+                    * uom_factor
                     * supplier_taxes_factor
                     * sale_taxes_factor
                     * profit_margin_factor

--- a/beesdoo_product/models/beesdoo_product.py
+++ b/beesdoo_product/models/beesdoo_product.py
@@ -142,13 +142,15 @@ class BeesdooProduct(models.Model):
                 product.scale_sale_unit = "P"
 
     def _get_main_supplier_info(self):
-        far_future = date(3000, 1, 1)
+        # fixme this function either returns a supplier or a collection.
+        #  wouldn’t it be more logical to return a supplier or None?
 
+        # supplierinfo w/o date_start come first
         def sort_date_first(seller):
             if seller.date_start:
                 return seller.date_start
             else:
-                return far_future
+                return date.max
 
         suppliers = self.seller_ids.sorted(key=sort_date_first, reverse=True)
         if suppliers:
@@ -207,8 +209,11 @@ class BeesdooProduct(models.Model):
     @api.depends("seller_ids", "seller_ids.date_start")
     def _compute_main_seller_id(self):
         for product in self:
-            # Calcule le vendeur associé qui a la date de début la plus récente
-            # et plus petite qu’aujourd’hui
+            # todo english code Calcule le vendeur associé qui a la date de
+            #  début la plus récente et plus petite qu’aujourd’hui fixme
+            #   could product.main_seller_id be used instead? it seems that
+            #   “seller” and “supplier” are used interchangeably in this
+            #   class. is this on purpose?
             sellers_ids = product._get_main_supplier_info()
             product.main_seller_id = (
                 sellers_ids and sellers_ids[0].name or False

--- a/beesdoo_product/tests/__init__.py
+++ b/beesdoo_product/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_suggested_price

--- a/beesdoo_product/tests/test_suggested_price.py
+++ b/beesdoo_product/tests/test_suggested_price.py
@@ -1,0 +1,99 @@
+# Copyright 2021 Coop IT Easy SCRL fs
+#   Robin Keunen <robin@coopiteasy.be>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+
+from odoo.tests import TransactionCase
+from odoo.tools import float_compare
+
+
+class TestSuggestedPrice(TransactionCase):
+    def setUp(self):
+        super(TestSuggestedPrice, self).setUp()
+
+        (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .set_param(
+                "beesdoo_product.suggested_price_reference", "sale_price"
+            )
+        )
+        self.account_type_ass = self.env.ref(
+            "account.data_account_type_current_assets"
+        )
+        self.a_debit_vat = self.env["account.account"].create(
+            {
+                "code": "debvat_acc",
+                "name": "debit vat account",
+                "user_type_id": self.account_type_ass.id,
+                "reconcile": False,
+            }
+        )
+        self.sale_tax_2_5 = self.env["account.tax"].create(
+            {
+                "name": "Tax 2.5 Incl.",
+                "amount": 2.5,
+                "amount_type": "percent",
+                "type_tax_use": "sale",
+                "account_id": self.a_debit_vat.id,
+                "price_include": True,
+            }
+        )
+        self.unit_uom = self.env.ref("uom.product_uom_unit")
+        self.kg_uom = self.env.ref("uom.product_uom_kgm")
+        self.product_category = self.env.ref("product.product_category_all")
+        self.product_category.should_round_suggested_price = True
+        self.supplier = self.env.ref("base.res_partner_1")
+        self.supplier.profit_margin = 25
+
+    def test_suggested_price_same_unit(self):
+        product = self.env["product.product"].create(
+            {
+                "name": "Test Product",
+                "taxes_id": [(4, self.sale_tax_2_5.id)],
+                "uom_id": self.unit_uom.id,
+                "uom_po_id": self.unit_uom.id,
+                "categ_id": self.product_category.id,
+            }
+        )
+        self.env["product.supplierinfo"].create(
+            {
+                "name": self.supplier.id,
+                "price": 14.77,
+                "product_tmpl_id": product.product_tmpl_id.id,
+            }
+        )
+        self.assertEqual(
+            float_compare(product.suggested_price, 20.20, precision_digits=3),
+            0,
+        )
+
+    def test_suggested_price_unit_conversion(self):
+        sale_unit = self.env["uom.uom"].create(
+            {
+                "category_id": self.env.ref("uom.product_uom_categ_kgm").id,
+                "name": "2.5 kg",
+                "factor": 2.5,
+                "rounding": 0.001,
+                "uom_type": "bigger",
+            }
+        )
+        product = self.env["product.product"].create(
+            {
+                "name": "Test Product",
+                "taxes_id": [(4, self.sale_tax_2_5.id)],
+                "uom_id": self.kg_uom.id,
+                "uom_po_id": sale_unit.id,
+                "categ_id": self.product_category.id,
+            }
+        )
+        self.env["product.supplierinfo"].create(
+            {
+                "name": self.supplier.id,
+                "price": 1.55,
+                "product_tmpl_id": product.product_tmpl_id.id,
+            }
+        )
+        self.assertEqual(
+            float_compare(product.suggested_price, 5.3, precision_digits=3), 0,
+        )

--- a/setup/beesdoo_product_info_screen/odoo/addons/beesdoo_product_info_screen
+++ b/setup/beesdoo_product_info_screen/odoo/addons/beesdoo_product_info_screen
@@ -1,0 +1,1 @@
+../../../../beesdoo_product_info_screen

--- a/setup/beesdoo_product_info_screen/setup.py
+++ b/setup/beesdoo_product_info_screen/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
## ~~[T4322 - SPP - Erreur d'arrondi sur le prix de vente](https://gestion.coopiteasy.be/web#id=7024&view_type=form&model=project.task)~~

**Before**: `profit_margin_factor` not rounded leads to suggested price being too high
**After**: round `profit_margin_factor` to two digits~~

## [T4325 - SPP - Autre souci avec le calcul du prix de vente - unités](https://gestion.coopiteasy.be/web#id=7027&view_type=form&model=project.task)

**Before**: only `uom_po_id.factor` is considered when computing suggested price
**After**: compute ratio between `uom_po_id.factor` and `uom_id.factor`.

## Refactoring
- Blacken file
- `product._get_main_supplier_info()` always returns singleton or empty record set => do not index suppliers.