### PR TITLE
[FIX] beesdoo_shifts: add shift template after creating status

### DIFF
--- a/beesdoo_shift/models/task.py
+++ b/beesdoo_shift/models/task.py
@@ -159,7 +159,7 @@ class Task(models.Model):
             worker = self.env["res.partner"].browse(vals["worker_id"])
             self.message_subscribe(partner_ids=worker.ids)
 
-    # TODO button to replaced someone
+    # TODO button to replace someone
     @api.model
     def unsubscribe_from_today(
         self,


### PR DESCRIPTION
# [TASK](https://gestion.coopiteasy.be/web#id=7248&view_type=form&model=project.task&action=475&active_id=198)

**Before**

On newly created workers, subcribing on a new shift template raises an error "Working mode is not properly defined. Please check if the worker is subscribed". The error is raised because the cooperator.status object is not yet created, cf https://github.com/beescoop/Obeesdoo/blob/3e1e48686659d55e958629d438854a71870b4ffc/beesdoo_shift/models/task.py#L382-L387 

^^^ waaaaaw ^^^

**Note**

The control flow is not staightforward: when adding or removing shifts template to a partner, res.partner.write calls `_update_shifts_on_subscribed_task_tmpl` and 
- unsubscribe the worker from the future shifts linked to the template
- subscribes the worker to the future shifts linked to the template

I did not add tests because the current tests already raised that case and were broken :grimacing: 

**After**
Adding the new script template is done **after** creating the cooperative.status.

**En passant**
Do not raise "no remaining spot" if the worker becomes irregular.
