### PR TITLE
Fix missing computed shifts in /my/shift webpage

### DIFF
--- a/beesdoo_website_shift/controllers/main.py
+++ b/beesdoo_website_shift/controllers/main.py
@@ -430,7 +430,9 @@ class WebsiteShiftController(http.Controller):
                 .get_param("beesdoo_website_shift.shift_period")
             )
 
-            for i in range(1, regular_next_shift_limit - nb_subscribed_shifts + 1):
+            for i in range(
+                1, regular_next_shift_limit - nb_subscribed_shifts + 1
+            ):
                 # Create the fictive shift
                 shift = main_shift.new()
                 shift.name = main_shift.name

--- a/beesdoo_website_shift/controllers/main.py
+++ b/beesdoo_website_shift/controllers/main.py
@@ -430,7 +430,7 @@ class WebsiteShiftController(http.Controller):
                 .get_param("beesdoo_website_shift.shift_period")
             )
 
-            for i in range(nb_subscribed_shifts, regular_next_shift_limit):
+            for i in range(1, regular_next_shift_limit-nb_subscribed_shifts + 1):
                 # Create the fictive shift
                 shift = main_shift.new()
                 shift.name = main_shift.name

--- a/beesdoo_website_shift/controllers/main.py
+++ b/beesdoo_website_shift/controllers/main.py
@@ -430,7 +430,7 @@ class WebsiteShiftController(http.Controller):
                 .get_param("beesdoo_website_shift.shift_period")
             )
 
-            for i in range(1, regular_next_shift_limit-nb_subscribed_shifts + 1):
+            for i in range(1, regular_next_shift_limit - nb_subscribed_shifts + 1):
                 # Create the fictive shift
                 shift = main_shift.new()
                 shift.name = main_shift.name


### PR DESCRIPTION
Hello, this is Esteve from Manresa, Catalonia! Thanks sharing your work!

I think we found a little bug, hopefully this PR fixes it:

ISSUE:
Suppose a regular worker has two shifts already created. Then if this worker goes to /my/shift the page will not show their 3rd next shift. The page will show the first two (the created ones) and then the 4th and so on.

FIX:
The webpage /my/shift shows the future shifts for a regular worker. Some of these shifts are real (they are shift objects in the database) and the rest of them are "fake" for that page (no db records). 

The loop that creates these "computed" shifts takes the last real shift and adds a multiple of a period to compute the next shifts. So if the last shift is day D and the period between shifts is 28 days, the first fake shift needs to be at D+28, then at D+2*28 until we have a total of L (limit) shifts.

So I've modified the loop condition. It seems that it can also be fixed by taking not the last shift but the first one. However it seems better indeed to take the last shift. We could also just mutiply by (i-nb_subscribed_shifts+1) instead of by i at the end of the loop body, and not touching the loop condition.

Regards!