### PR TITLE
[ADD] beesdoo_shift: next_shift_id on cooperative.status

### DIFF
--- a/beesdoo_shift/data/cron.xml
+++ b/beesdoo_shift/data/cron.xml
@@ -1,7 +1,7 @@
 <odoo>
     <data noupdate="1">
         <record id="ir_cron_update_today" model="ir.cron">
-            <field name="name">Update Cooperatoor status base on the date</field>
+            <field name="name">Update Cooperator status base on the date</field>
             <field name="model_id" ref="model_cooperative_status" />
             <field name="state">code</field>
             <field name="code">model._set_today()</field>

--- a/beesdoo_shift/models/res_partner.py
+++ b/beesdoo_shift/models/res_partner.py
@@ -18,6 +18,8 @@ class ResPartner(models.Model):
         compute="_compute_can_shop",
         store=True,
     )
+    # todo implement as delegated inheritance ?
+    #  resolve as part of migration to OCA
     cooperative_status_ids = fields.One2many(
         string="Cooperative Statuses",
         comodel_name="cooperative.status",
@@ -64,8 +66,23 @@ class ResPartner(models.Model):
     subscribed_shift_ids = fields.Many2many(
         comodel_name="beesdoo.shift.template", readonly=True
     )
-    shift_task_ids = fields.One2many(
-        "beesdoo.shift.shift", "worker_id", string="Shifts"
+    shift_shift_ids = fields.One2many(
+        comodel_name="beesdoo.shift.shift",
+        inverse_name="worker_id",
+        string="Shifts",
+        help="All the shifts the worker is subscribed to.",
+    )
+    next_shift_id = fields.Many2one(
+        related="cooperative_status_ids.next_shift_id",
+        store=True,
+    )
+    is_subscribed_to_shift = fields.Boolean(
+        related="cooperative_status_ids.is_subscribed_to_shift",
+        store=True,
+    )
+    next_shift_date = fields.Datetime(
+        related="cooperative_status_ids.next_shift_date",
+        store=True,
     )
 
     @api.depends("cooperative_status_ids")

--- a/beesdoo_shift/models/task.py
+++ b/beesdoo_shift/models/task.py
@@ -9,9 +9,7 @@ from odoo.tools.translate import _
 
 class Task(models.Model):
     _name = "beesdoo.shift.shift"
-
     _inherit = ["mail.thread"]
-
     _order = "start_time asc"
 
     ##################################

--- a/beesdoo_shift/views/cooperative_status.xml
+++ b/beesdoo_shift/views/cooperative_status.xml
@@ -104,7 +104,7 @@
                     <separator string="Subscribed Shift" />
                     <field name="subscribed_shift_ids" />
                     <separator string="Shifts" />
-                    <field name="shift_task_ids" />
+                    <field name="shift_shift_ids" />
                 </page>
             </xpath>
         </field>
@@ -151,6 +151,8 @@
                         <field name="can_shop" />
                     </group>
                     <group string="Timing information">
+                        <field name="next_shift_id" />
+                        <field name="next_shift_date" />
                         <field
                             name="next_countdown_date"
                             readonly="1"
@@ -158,6 +160,11 @@
                         />
                         <field
                             name="future_alert_date"
+                            readonly="1"
+                            attrs="{'invisible':[('working_mode', '!=', 'irregular')]}"
+                        />
+                        <field
+                            name="is_subscribed_to_shift"
                             readonly="1"
                             attrs="{'invisible':[('working_mode', '!=', 'irregular')]}"
                         />


### PR DESCRIPTION
- add a boolean : worker subscribed before alert date
- add next shift and next shift date to the worker status form

I needed to add `shift_shift_ids` to `res.partner` to trigger the computation. I hope it does not impact performance, maybe @tfrancoi knows.

- Question to @remytms : should I make my function depend on `today` field ?
- I could not write tests for `is_subscribed_to_shift` computation since the `next_alert_date" is computed in overriding modules.

[task](https://gestion.coopiteasy.be/web?#id=7720&view_type=form&model=project.task&action=479)
