### PR TITLE
[FIX] beesdoo_product: fix computed field total_with_vat

### DIFF
--- a/beesdoo_product/__manifest__.py
+++ b/beesdoo_product/__manifest__.py
@@ -15,7 +15,7 @@
     "author": "Beescoop - Cellule IT, Coop IT Easy SCRLfs",
     "website": "https://github.com/beescoop/Obeesdoo",
     "category": "Sales",
-    "version": "12.0.1.2.0",
+    "version": "12.0.1.3.0",
     "depends": [
         "product",
         "sale",

--- a/beesdoo_product/models/beesdoo_product.py
+++ b/beesdoo_product/models/beesdoo_product.py
@@ -92,6 +92,11 @@ class BeesdooProduct(models.Model):
     total_deposit = fields.Float(
         compute="_compute_total", store=True, string="Deposit Price"
     )
+    several_tax_strategies_warning = fields.Boolean(
+        string="This product can't be printed from the Point"
+        " of Sale because several tax strategies were defined.",
+        compute="_compute_total",
+    )
 
     label_to_be_printed = fields.Boolean("Print label?")
     label_last_printed = fields.Datetime("Label last printed on")
@@ -220,18 +225,26 @@ class BeesdooProduct(models.Model):
             consignes_group = self.env.ref(
                 "beesdoo_product.consignes_group_tax", raise_if_not_found=False
             )
+            product.several_tax_strategies_warning = False
 
-            taxes_included = set(product.taxes_id.filtered(
-                lambda t: t.tax_group_id != consignes_group
-            ).mapped("price_include"))
+            taxes_included = set(
+                product.taxes_id.filtered(
+                    lambda t: t.tax_group_id != consignes_group
+                ).mapped("price_include")
+            )
 
             if len(taxes_included) == 0:
                 product.total_with_vat = product.list_price
                 return True
 
             elif len(taxes_included) > 1:
-                pass
-                # TODO Display an error to the user ?
+                _logger.warning(
+                    "Several tax strategies (price_include)"
+                    " defined for product (%s, %s)",
+                    product.id,
+                    product.name,
+                )
+                product.several_tax_strategies_warning = True
 
             elif taxes_included.pop():
                 product.total_with_vat = product.list_price

--- a/beesdoo_product/models/beesdoo_product.py
+++ b/beesdoo_product/models/beesdoo_product.py
@@ -221,26 +221,20 @@ class BeesdooProduct(models.Model):
                 "beesdoo_product.consignes_group_tax", raise_if_not_found=False
             )
 
-            taxes_included = set(product.taxes_id.mapped("price_include"))
+            taxes_included = set(product.taxes_id.filtered(
+                lambda t: t.tax_group_id != consignes_group
+            ).mapped("price_include"))
+
             if len(taxes_included) == 0:
                 product.total_with_vat = product.list_price
                 return True
 
             elif len(taxes_included) > 1:
-                raise ValidationError(
-                    _("Several tax strategies (price_include) defined for %s")
-                    % product.name
-                )
+                pass
+                # TODO Display an error to the user ?
 
             elif taxes_included.pop():
                 product.total_with_vat = product.list_price
-                product.total_deposit = sum(
-                    [
-                        tax._compute_amount(product.list_price, product.list_price)
-                        for tax in product.taxes_id
-                        if tax.tax_group_id == consignes_group
-                    ]
-                )
             else:
                 tax_amount_sum = sum(
                     [

--- a/beesdoo_product/views/beesdoo_product.xml
+++ b/beesdoo_product/views/beesdoo_product.xml
@@ -33,6 +33,15 @@
             >
                 <attribute name="invisible">1</attribute>
             </field>
+            <xpath expr="//h1" position="after">
+                <field name="several_tax_strategies_warning" attrs="{'invisible': 1}" />
+                <label
+                    for="several_tax_strategies_warning"
+                    decoration-warning="True"
+                    style="color:Red"
+                    attrs="{'invisible': [('several_tax_strategies_warning', '!=', True)]}"
+                />
+            </xpath>
             <xpath expr="//group[@name='inventory']/.." position="after">
                 <page string="Label">
                     <group>


### PR DESCRIPTION
- Don't raise ValidationError in stored computed field it may crash at module installation
- Handle case were deposit is tax excluded, exclude them from the tax computation
  and include them at the end in the deposit field
- Error message is displayed on the product if the total can't be computed because of multiple tax strategies

<img width="941" alt="Screenshot 2022-06-23 at 16 22 55" src="https://user-images.githubusercontent.com/3082119/175322811-919d0986-85a3-4683-bc03-42e63af4c7a2.png">

