### PR TITLE
[FIX] beesdoo_easy_my_coop: _cooperator_share_type return type

### DIFF
--- a/beesdoo_easy_my_coop/models/res_partner.py
+++ b/beesdoo_easy_my_coop/models/res_partner.py
@@ -23,7 +23,7 @@ class Partner(models.Model):
         Return the share.type that correspond to the cooperator_type.
         """
         self.ensure_one()
-        share_type = None
+        share_type = self.env["product.template"]
         if self.cooperator_type:
             share_type = (
                 self.env["product.template"].search(


### PR DESCRIPTION
_cooperator_share_type should always return a record set
even if it's an empty one