### PR TITLE
[ADD] beesdoo_easy_my_coop: force is_worker

### DIFF
--- a/beesdoo_easy_my_coop/models/res_partner.py
+++ b/beesdoo_easy_my_coop/models/res_partner.py
@@ -8,6 +8,13 @@ from odoo.exceptions import ValidationError
 class Partner(models.Model):
     _inherit = "res.partner"
 
+    # this field is not displayed in the view
+    # cf issue https://github.com/beescoop/Obeesdoo/issues/374
+    worker_store = fields.Boolean(
+        string="Force Worker",
+        help="Check to subscribe member to their shift even"
+        " if they are not yet effective cooperator.",
+    )
     info_session_confirmed = fields.Boolean(
         string="Confirmed presence to info session", default=False
     )
@@ -58,7 +65,7 @@ class Partner(models.Model):
             [("share_product_id.allow_working", "=", "True")]
         )
         partner_ids = lines.mapped("partner_id")
-        partner_ids |= self.search([('worker_store', '=', True)])
+        partner_ids |= self.search([("worker_store", "=", True)])
         if (operator, value) in [("=", True), ("!=", False)]:
             return [("id", "in", partner_ids.ids)]
         else:

--- a/beesdoo_shift/models/res_partner.py
+++ b/beesdoo_shift/models/res_partner.py
@@ -10,8 +10,9 @@ class ResPartner(models.Model):
     """
 
     _inherit = "res.partner"
-
     worker_store = fields.Boolean(default=False)
+    # is_worker will be overriden in depending module
+    # implementing the specific processes
     is_worker = fields.Boolean(related="worker_store", string="Worker", readonly=False)
     can_shop = fields.Boolean(
         string="Is worker allowed to shop?",


### PR DESCRIPTION
In some use case you want to be able to subscribe
member to their shift even if they are not yet effective cooperator

use worker_store as field to force the is_worker

- Change depends and and compute of is_Worker
- Adapt search function to take into account worker_store