### PR TITLE
[FIX] beesdoo_shift: fix modularity

### DIFF
--- a/beesdoo_shift/models/task.py
+++ b/beesdoo_shift/models/task.py
@@ -61,7 +61,7 @@ class Task(models.Model):
     )
     end_time = fields.Datetime(track_visibility="always", required=True)
     state = fields.Selection(
-        selection=_get_selection_status,
+        selection=lambda x: x._get_selection_status(),
         default="open",
         required=True,
         track_visibility="onchange",

--- a/beesdoo_worker_status/models/cooperative_status.py
+++ b/beesdoo_worker_status/models/cooperative_status.py
@@ -351,7 +351,7 @@ class CooperativeStatus(models.Model):
     #        Irregular Cron implementation        #
     ###############################################
 
-    def _get_irregular_worker_domain(self, **kwargs):
+    def _get_irregular_worker_domain(self, today):
         today = kwargs.get("today") or self.today
         return [
             "&",


### PR DESCRIPTION
- Dynamic selection should be called with a lambda
- Clear signature for _get_irregular_worker_domain
- Modular list of field to watch for tracking history