### PR TITLE
[FIX] beesdoo_shift: forbid illegal hour

### DIFF
--- a/beesdoo_shift/models/planning.py
+++ b/beesdoo_shift/models/planning.py
@@ -214,10 +214,19 @@ class TaskTemplate(models.Model):
                     )
                 )
 
+    @api.constrains("start_time", "end_time")
+    def _check_real_hour(self):
+        for rec in self:
+            if not (-0.001 < rec.start_time < 24) or not (
+                -0.001 < rec.end_time < 24
+            ):
+                raise UserError(
+                    _("Start time and End time need to be between 0 and 23:59")
+                )
+
     @api.onchange("start_time", "end_time")
     def _get_duration(self):
-        if self.start_time and self.end_time:
-            self.duration = self.end_time - self.start_time
+        self.duration = (self.end_time or 0.0) - (self.start_time or 0.0)
 
     @api.onchange("duration")
     def _set_duration(self):


### PR DESCRIPTION
It was possible to encode shift that start at negative hour
or hour bigger then 24. Of course this lead to some
error at the moment we generate the planning for a given date

- Add a constraint on start_time and end_time
- Fix onchange on duration: duration was not computed properly
when the start or end time was 00:00