### PR TITLE
[ADD] beesdoo_shift: allow to create user

### DIFF
--- a/beesdoo_product/views/beesdoo_product.xml
+++ b/beesdoo_product/views/beesdoo_product.xml
@@ -218,6 +218,7 @@
     <record model="ir.ui.view" id="beesdoo_product_supplierinfo_tree_view">
         <field name="name">beesdoo.product.supplierinfo.tree</field>
         <field name="model">product.supplierinfo</field>
+        <field name="priority" eval="100" />
         <field name="inherit_id" ref="product.product_supplierinfo_tree_view" />
         <field name="arch" type="xml">
             <field name="price" position="replace">

--- a/beesdoo_shift/wizard/subscribe.py
+++ b/beesdoo_shift/wizard/subscribe.py
@@ -116,7 +116,9 @@ class Subscribe(models.TransientModel):
     irregular_start_date = fields.Date(string="Start Date", default=fields.Date.today)
     resigning = fields.Boolean(default=False, help="Want to leave the beescoop")
     create_user = fields.Boolean(
-        defaul=False, help="Create a portal user for the new worker"
+        default=False,
+        help="Create a portal user for the new worker."
+        " If a user exists, nothing is done.",
     )
 
     @api.multi

--- a/beesdoo_shift/wizard/subscribe.py
+++ b/beesdoo_shift/wizard/subscribe.py
@@ -115,6 +115,9 @@ class Subscribe(models.TransientModel):
     )
     irregular_start_date = fields.Date(string="Start Date", default=fields.Date.today)
     resigning = fields.Boolean(default=False, help="Want to leave the beescoop")
+    create_user = fields.Boolean(
+        defaul=False, help="Create a portal user for the new worker"
+    )
 
     @api.multi
     def unsubscribe(self):
@@ -182,9 +185,21 @@ class Subscribe(models.TransientModel):
             # ,...
             status_id.sudo().write(data)
 
+        if self.create_user:
+            self._create_user()
+
         # add the new shift template
         if self.shift_id and self.working_mode == "regular":
             self.cooperator_id.sudo().write(
                 {"subscribed_shift_ids": [(4, self.shift_id.id, False)]}
             )
         return True
+
+    def _create_user(self):
+        PortalWizard = self.env["portal.wizard"].sudo()
+        wiz_values = PortalWizard.with_context(
+            active_ids=self.cooperator_id.ids
+        ).default_get(["user_ids"])
+        wizard = PortalWizard.create(wiz_values)
+        wizard.user_ids.write({"in_portal": True})
+        wizard.action_apply()

--- a/beesdoo_shift/wizard/subscribe.xml
+++ b/beesdoo_shift/wizard/subscribe.xml
@@ -31,6 +31,7 @@
                         name="irregular_start_date"
                         attrs="{'invisible': [('working_mode', '!=', 'irregular')]}"
                     />
+                    <field name="create_user" />
                     <field name="super" />
                     <field name="reset_counter" />
                     <field

--- a/polln_shift/views/shift.xml
+++ b/polln_shift/views/shift.xml
@@ -128,7 +128,7 @@
         <field name="name">Subscribe Cooperator</field>
         <field name="model">beesdoo.shift.subscribe</field>
         <field name="inherit_id" ref="beesdoo_shift.subscribe_coop_wizard_view_form" />
-        <field name="b">100</field>
+        <field name="priority" eval="100" />
         <field name="arch" type="xml">
             <field name="shift_id" position="replace">
                 <field


### PR DESCRIPTION
When a new cooperator subscribe
add a checkbox to allow to create a portal user
if the user already exist nothing will happen