### PR TITLE
[12.0] add a configuration for default shift status on attendance sheets

### DIFF
--- a/beesdoo_shift_attendance/__manifest__.py
+++ b/beesdoo_shift_attendance/__manifest__.py
@@ -11,7 +11,7 @@
     "author": "Elouan Le Bars, Coop IT Easy SCRLfs",
     "website": "https://github.com/beescoop/Obeesdoo",
     "category": "Cooperative management",
-    "version": "12.0.1.0.2",
+    "version": "12.0.1.1.2",
     "depends": [
         "beesdoo_base",
         "beesdoo_shift",

--- a/beesdoo_shift_attendance/models/res_config_settings.py
+++ b/beesdoo_shift_attendance/models/res_config_settings.py
@@ -1,7 +1,7 @@
 # Copyright 2019-2020 Elouan Le Bars <elouan@coopiteasy.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class ResConfigSettings(models.TransientModel):
@@ -16,6 +16,7 @@ class ResConfigSettings(models.TransientModel):
         string="Default Task Type",
         help="Default task type for attendance sheet pre-filling",
         required=True,
+        config_parameter="beesdoo_shift_attendance.pre_filled_task_type_id",
         default=False,
     )
     attendance_sheet_generation_interval = fields.Integer(
@@ -40,25 +41,3 @@ class ResConfigSettings(models.TransientModel):
         ),
         help="Default state set for shifts on attendance sheets",
     )
-
-    # todo remove get and set functions, part of odoo base
-    @api.multi
-    def set_values(self):
-        super(ResConfigSettings, self).set_values()
-        parameters = self.env["ir.config_parameter"].sudo()
-        parameters.set_param(
-            "beesdoo_shift_attendance.pre_filled_task_type_id",
-            str(self.pre_filled_task_type_id.id),
-        )
-
-    @api.multi
-    def get_values(self):
-        res = super(ResConfigSettings, self).get_values()
-        res.update(
-            pre_filled_task_type_id=int(
-                self.env["ir.config_parameter"].get_param(
-                    "beesdoo_shift_attendance.pre_filled_task_type_id"
-                )
-            )
-        )
-        return res

--- a/beesdoo_shift_attendance/models/res_config_settings.py
+++ b/beesdoo_shift_attendance/models/res_config_settings.py
@@ -12,7 +12,7 @@ class ResConfigSettings(models.TransientModel):
         config_parameter="beesdoo_shift_attendance.card_support",
     )
     pre_filled_task_type_id = fields.Many2one(
-        "beesdoo.shift.type",
+        comodel_name="beesdoo.shift.type",
         string="Default Task Type",
         help="Default task type for attendance sheet pre-filling",
         required=True,
@@ -26,7 +26,22 @@ class ResConfigSettings(models.TransientModel):
             "beesdoo_shift_attendance.attendance_sheet_generation_interval"
         ),
     )
+    attendance_sheet_default_shift_state = fields.Selection(
+        [
+            ("done", "Present"),
+            ("absent_0", "Absent - 0 Compensation"),
+            ("absent_1", "Absent - 1 Compensation"),
+            ("absent_2", "Absent - 2 Compensations"),
+        ],
+        string="Default Shift State",
+        required=True,
+        config_parameter=(
+            "beesdoo_shift_attendance.attendance_sheet_default_shift_state"
+        ),
+        help="Default state set for shifts on attendance sheets",
+    )
 
+    # todo remove get and set functions, part of odoo base
     @api.multi
     def set_values(self):
         super(ResConfigSettings, self).set_values()

--- a/beesdoo_shift_attendance/tests/test_beesdoo_shift.py
+++ b/beesdoo_shift_attendance/tests/test_beesdoo_shift.py
@@ -20,7 +20,7 @@ class TestBeesdooShift(TransactionCase):
         self.pre_filled_task_type_id = (
             self.env["ir.config_parameter"]
             .sudo()
-            .get_param("beesdoo_shift.pre_filled_task_type_id")
+            .get_param("beesdoo_shift_attendance.pre_filled_task_type_id")
         )
 
         self.current_time = datetime.now()

--- a/beesdoo_shift_attendance/tests/test_beesdoo_shift.py
+++ b/beesdoo_shift_attendance/tests/test_beesdoo_shift.py
@@ -152,6 +152,7 @@ class TestBeesdooShift(TransactionCase):
             {
                 "pre_filled_task_type_id": self.task_type_1.id,
                 "attendance_sheet_generation_interval": 15,
+                "attendance_sheet_default_shift_state": "done",
             }
         )
         setting_wizard_1.execute()
@@ -181,14 +182,12 @@ class TestBeesdooShift(TransactionCase):
 
         # Test consistency with actual shift for sheet 1
         for shift in sheet_1.expected_shift_ids:
-            self.assertEquals(shift.worker_id, shift.task_id.worker_id)
-            self.assertEquals(shift.replaced_id, shift.task_id.replaced_id)
+            self.assertEqual(shift.worker_id, shift.task_id.worker_id)
+            self.assertEqual(shift.replaced_id, shift.task_id.replaced_id)
             self.assertEqual(shift.task_type_id, shift.task_id.task_type_id)
             self.assertEqual(shift.super_coop_id, shift.task_id.super_coop_id)
             self.assertEqual(shift.working_mode, shift.task_id.working_mode)
-
-            # Status should be "absent" for all shifts
-            self.assertEquals(shift.state, "absent_2")
+            self.assertEqual(shift.state, "done")  # cf settings
 
         # Empty shift should be considered in max worker number calculation
         self.assertEqual(sheet_1.max_worker_no, 4)

--- a/beesdoo_shift_attendance/views/res_config_settings_view.xml
+++ b/beesdoo_shift_attendance/views/res_config_settings_view.xml
@@ -93,6 +93,32 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="row mt16 o_settings_container">
+                            <div class="col-12 col-lg-6 o_setting_box">
+                                <div class="o_setting_right_pane">
+                                    <span class="o_form_label">
+                                        Default Shift Attendance Status
+                                    </span>
+                                    <div class="text-muted">
+                                        For attendance sheets automatic pre-filling.
+                                    </div>
+                                    <div class="content-group">
+                                        <div class="mt16 row">
+                                            <label
+                                                for="attendance_sheet_default_shift_state"
+                                                string="State"
+                                                class="col-3 col-lg-3 o_light_label"
+                                            />
+                                            <field
+                                                name="attendance_sheet_default_shift_state"
+                                                class="oe_inline"
+                                                required="1"
+                                            />
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </xpath>
             </field>


### PR DESCRIPTION
## Description

Add a configuration for default shift status on attendance sheets

## Odoo task (if applicable)

https://gestion.coopiteasy.be/web#id=8282&view_type=form&model=project.task

## Checklist before approval

- [x] Tests are present (or not needed).
- [x] Credits/copyright have been changed correctly.
- [x] (If a new module) Moving this to OCA has been considered.
