### PR TITLE
Make field revert_info readonly on beesdoo_shift task view

### DIFF
--- a/beesdoo_shift/views/task.xml
+++ b/beesdoo_shift/views/task.xml
@@ -183,7 +183,7 @@
                         <group>
                             <field name="start_time" />
                             <field name="end_time" />
-                            <field name="revert_info" invisible="0" />
+                            <field name="revert_info" invisible="0" readonly="1" />
                         </group>
                     </group>
                 </sheet>


### PR DESCRIPTION
Τhis field allows to restore the counters to their correct state if there is an error in the state of a shift. The value is calculated automatically when an employee is assigned. This pull request makes the field readonly in order to avoid manual value assignation.
