### PR TITLE
[ADD] b_website_shift: ability for irregualar workers to unsubscribe from a shift

### DIFF
--- a/beesdoo_shift/models/task.py
+++ b/beesdoo_shift/models/task.py
@@ -81,6 +81,7 @@ class Task(models.Model):
     )
     revert_info = fields.Text(copy=False)
     working_mode = fields.Selection(related="worker_id.working_mode")
+    can_unsubscribe = fields.Boolean(compute="_compute_can_unsubscribe")
 
     def _expand_states(self, states, domain, order):
         return [key for key, val in self._fields["state"].selection(self)]
@@ -89,6 +90,20 @@ class Task(models.Model):
     def _compute_color(self):
         for rec in self:
             rec.color = self._get_color_mapping(rec.state)
+
+    def _compute_can_unsubscribe(self):
+        now = datetime.now()
+        ICP = self.env["ir.config_parameter"].sudo()
+        max_hours = int(
+            ICP.get_param("beesdoo_website_shift.max_hours_to_unsubscribe", 2)
+        )
+        for rec in self:
+            if now > rec.start_time or rec.state != "open":
+                rec.can_unsubscribe = False
+            else:
+                delta = rec.start_time - now
+                delta = delta.seconds / 3600.0 + delta.days * 24
+                rec.can_unsubscribe = delta >= max_hours
 
     @api.constrains("state")
     def _lock_future_task(self):

--- a/beesdoo_website_shift/controllers/main.py
+++ b/beesdoo_website_shift/controllers/main.py
@@ -212,6 +212,7 @@ class WebsiteShiftController(http.Controller):
         if request.env.user.partner_id != shift.worker_id or not shift.can_unsubscribe:
             raise Forbidden()
         shift.worker_id = False
+        request.session["unsubscribe_success"] = True
         return request.redirect(kw["nexturl"])
 
     def my_shift_irregular_worker(self, nexturl=""):
@@ -240,6 +241,12 @@ class WebsiteShiftController(http.Controller):
             template_context["back_from_subscription"] = True
             template_context["success"] = request.session.get("success")
             del request.session["success"]
+        if "unsubscribe_success" in request.session:
+            template_context["back_from_subscription"] = True
+            template_context["unsubscribe_success"] = request.session.get(
+                "unsubscribe_success"
+            )
+            del request.session["unsubscribe_success"]
 
         # Add setting for subscription allowed time
         # TODO: move this to the attendance_sheet module

--- a/beesdoo_website_shift/data/res_config_data.xml
+++ b/beesdoo_website_shift/data/res_config_data.xml
@@ -9,5 +9,9 @@
             <field name="key">beesdoo_website_shift.shift_period</field>
             <field name="value">28</field>
         </record>
+        <record id="max_hours_to_unsubscribe" model="ir.config_parameter">
+            <field name="key">beesdoo_website_shift.max_hours_to_unsubscribe</field>
+            <field name="value">2</field>
+        </record>
     </data>
 </odoo>

--- a/beesdoo_website_shift/views/my_shift_website_templates.xml
+++ b/beesdoo_website_shift/views/my_shift_website_templates.xml
@@ -894,7 +894,7 @@
                         <div
                             t-if="back_from_subscription"
                             role="alert"
-                            t-att-class="'alert alert-%s alert-dismissible' % ('success' if success else 'danger',)"
+                            t-att-class="'alert alert-%s alert-dismissible' % ('success' if (success or unsubscribe_success) else 'danger',)"
                         >
                             <button
                                 type="button"
@@ -908,7 +908,11 @@
                                 <strong>Success!</strong>
                                 Your subscription has succeded.
                             </t>
-                            <t t-if="not success">
+                            <t t-elif="unsubscribe_success">
+                                <strong>Success!</strong>
+                                You have been successfully unsubscribed.
+                            </t>
+                            <t t-else="">
                                 <strong>Failed!</strong>
                                 Your subscription has failed. Someone
                                 subscribed before you or the shift was deleted.

--- a/beesdoo_website_shift/views/my_shift_website_templates.xml
+++ b/beesdoo_website_shift/views/my_shift_website_templates.xml
@@ -157,7 +157,17 @@
                     </t>
                 </div>
                 <div class="card-body clearfix">
-                    <t t-esc="shift.task_type_id.name" />
+                    <t t-esc="shift.task_template_id.name or shift.task_type_id.name" />
+                    <button
+                        type="button"
+                        class="btn btn-danger btn-sm pull-right"
+                        data-toggle="modal"
+                        t-att-data-target="'#unsubscribe-shift-%s' % shift.id"
+                        t-if="shift.can_unsubscribe"
+                    >
+                        <span class="fa fa-user-plus" aria-hidden="true" />
+                        Unsubscribe
+                    </button>
                     <button
                         type="button"
                         class="btn btn-default btn-sm pull-right"
@@ -220,6 +230,53 @@
                     </div>
                 </div>
             </div>
+            <t t-foreach="subscribed_shifts" t-as="shift">
+                <div
+                    class="modal fade"
+                    t-att-id="'unsubscribe-shift-%s' % shift.id"
+                    tabindex="-1"
+                    role="dialog"
+                    t-att-aria-labelledby="'unsubscribe-shift-%s-label' % shift.id"
+                >
+                    <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h4
+                                    class="modal-title"
+                                    t-att-id="'subscribe-shift-%s-label' % shift.id"
+                                >
+                                    Please confirm unsubscriptions
+                                </h4>
+                            </div>
+                            <div class="modal-body">
+                                <span t-field="shift.start_time" />
+                                -
+                                <span
+                                    t-field="shift.end_time"
+                                    t-options='{"format": "HH:mm"}'
+                                />
+                                <br />
+                                <t t-esc="shift.task_type_id.name" />
+                            </div>
+                            <div class="modal-footer">
+                                <button
+                                    type="button"
+                                    class="btn btn-default"
+                                    data-dismiss="modal"
+                                >Close
+                                </button>
+                                <a
+                                    class="btn btn-primary"
+                                    t-if="irregular_enable_sign_up"
+                                    t-att-href="'/shift/%s/unsubscribe?nexturl=%s' % (shift.id, nexturl)"
+                                >
+                                    Unsubscribe
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </t>
         </t>
 
         <div class="alert alert-warning" t-if="not subscribed_shifts">


### PR DESCRIPTION
Code by @tfrancoi

## Description

Add an "unsubscribe" button next to the shift on webpage "My shifts" of the portal for irregular workers.
The unsubscription is impossible less than X hours before the shift, X being configurable. 

## Checklist before approval

- [ ] Tests are present (or not needed).
- [ ] Credits/copyright have been changed correctly.
- [ ] (If a new module) Moving this to OCA has been considered.
