### PR TITLE
[FIX] beesdoo_shift: Don't raise an error when worker_id is undefined

### DIFF
--- a/beesdoo_shift/README.rst
+++ b/beesdoo_shift/README.rst
@@ -44,6 +44,15 @@ Configuration
 
   - Its interval number (default = 7) should be consistent with notice (default = 1) and period (default = 7).
 
+Changelog
+=========
+
+12.0.1.1.1 (2022-05-26)
+**Bugfixes**
+
+- No longer raise an error when unsubscribing a replacement worker using the
+  wizard. (`#389 <https://github.com/beescoop/obeesdoo/issues/389>`_)
+
 Bug Tracker
 ===========
 

--- a/beesdoo_shift/__manifest__.py
+++ b/beesdoo_shift/__manifest__.py
@@ -9,7 +9,7 @@
     "author": "Thibault Francois, Elouan Le Bars, Coop IT Easy SCRLfs",
     "website": "https://github.com/beescoop/Obeesdoo",
     "category": "Cooperative management",
-    "version": "12.0.1.1.0",
+    "version": "12.0.1.1.1",
     "depends": ["mail"],
     "data": [
         "data/system_parameter.xml",

--- a/beesdoo_shift/models/task.py
+++ b/beesdoo_shift/models/task.py
@@ -321,18 +321,21 @@ class Task(models.Model):
         if always_update or not (self.worker_id or self.replaced_id):
             return
 
-        if not (self.worker_id.working_mode in ["regular", "irregular"]):
+        if self.worker_id and self.worker_id.working_mode not in [
+            "regular",
+            "irregular",
+        ]:
             raise UserError(
                 _(
                     "Working mode is not properly defined. Please check if "
                     "the worker is subscribed "
                 )
             )
-
-        data, status = self._get_counter_date_state_change(new_state)
-        if status:
-            status.sudo()._change_counter(data)
-            self._set_revert_info(data, status)
+        if self.worker_id:
+            data, status = self._get_counter_date_state_change(new_state)
+            if status:
+                status.sudo()._change_counter(data)
+                self._set_revert_info(data, status)
 
     @api.model
     def _cron_send_weekly_emails(self, notice=1, period=7):

--- a/beesdoo_shift/models/task.py
+++ b/beesdoo_shift/models/task.py
@@ -238,9 +238,10 @@ class Task(models.Model):
                         # values and proper name instead of copying
                         # a existing shift that may have modified
                         # default values.
-                        shifts[0].copy(
-                            default={"is_regular": True}
-                        ).worker_id = worker_id
+                        copied_shift = shifts[0].copy()
+                        copied_shift.write(
+                            {"is_regular": True, "worker_id": worker_id.id}
+                        )
             # Super coop subscription
             for worker_id in worker_ids:
                 if task_tmpl_id.super_coop_id == worker_id:

--- a/beesdoo_shift/models/task.py
+++ b/beesdoo_shift/models/task.py
@@ -72,6 +72,7 @@ class Task(models.Model):
     is_compensation = fields.Boolean(default=False, string="Compensation shift")
     replaced_id = fields.Many2one(
         "res.partner",
+        string="Replaced By",
         track_visibility="onchange",
         domain=[
             ("eater", "=", "worker_eater"),

--- a/beesdoo_shift/readme/HISTORY.rst
+++ b/beesdoo_shift/readme/HISTORY.rst
@@ -1,0 +1,5 @@
+12.0.1.1.1 (2022-05-26)
+**Bugfixes**
+
+- No longer raise an error when unsubscribing a replacement worker using the
+  wizard. (`#389 <https://github.com/beescoop/obeesdoo/issues/389>`_)

--- a/beesdoo_shift/readme/newsfragments/389.bugfix.rst
+++ b/beesdoo_shift/readme/newsfragments/389.bugfix.rst
@@ -1,0 +1,2 @@
+No longer raise an error when unsubscribing a replacement worker using the
+wizard.

--- a/beesdoo_shift/readme/newsfragments/389.bugfix.rst
+++ b/beesdoo_shift/readme/newsfragments/389.bugfix.rst
@@ -1,2 +1,0 @@
-No longer raise an error when unsubscribing a replacement worker using the
-wizard.

--- a/beesdoo_shift/static/description/index.html
+++ b/beesdoo_shift/static/description/index.html
@@ -372,18 +372,19 @@ ul.auto-toc {
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#configuration" id="id1">Configuration</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id6">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="id2">Configuration</a></li>
+<li><a class="reference internal" href="#changelog" id="id3">Changelog</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id4">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id5">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id6">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id7">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id8">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
 <div class="section" id="configuration">
-<h1><a class="toc-backref" href="#id1">Configuration</a></h1>
+<h1><a class="toc-backref" href="#id2">Configuration</a></h1>
 <ul class="simple">
 <li>Translate cooperative status selection field, the terms to translate are:<ul>
 <li>shift_status_up_to_date,</li>
@@ -402,8 +403,17 @@ ul.auto-toc {
 </li>
 </ul>
 </div>
+<div class="section" id="changelog">
+<h1><a class="toc-backref" href="#id3">Changelog</a></h1>
+<p>12.0.1.1.1 (2022-05-26)
+<strong>Bugfixes</strong></p>
+<ul class="simple">
+<li>No longer raise an error when unsubscribing a replacement worker using the
+wizard. (<a class="reference external" href="https://github.com/beescoop/obeesdoo/issues/389">#389</a>)</li>
+</ul>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id4">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/beescoop/obeesdoo/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -411,9 +421,9 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id3">Credits</a></h1>
+<h1><a class="toc-backref" href="#id5">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id4">Authors</a></h2>
+<h2><a class="toc-backref" href="#id6">Authors</a></h2>
 <ul class="simple">
 <li>Thibault Francois</li>
 <li>Elouan Le Bars</li>
@@ -421,14 +431,14 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id7">Contributors</a></h2>
 <ul class="simple">
 <li>Beescoop - Cellule IT</li>
 <li>Coop IT Easy SCRLfs</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id8">Maintainers</a></h2>
 <p>This module is part of the <a class="reference external" href="https://github.com/beescoop/obeesdoo/tree/12.0/beesdoo_shift">beescoop/obeesdoo</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>


### PR DESCRIPTION
## Description



## Odoo task (if applicable)

https://gestion.coopiteasy.be/web#view_type=form&model=project.task&id=8529&active_id=8529&menu_id=

## Checklist before approval

- [ ] Tests are present (or not needed).
- [ ] Credits/copyright have been changed correctly.
- [ ] (If a new module) Moving this to OCA has been considered.
