### PR TITLE
[FIX] beesdoo_shift: Check working mode as well as shift_id

### DIFF
--- a/beesdoo_shift/README.rst
+++ b/beesdoo_shift/README.rst
@@ -47,6 +47,13 @@ Configuration
 Changelog
 =========
 
+12.0.1.1.4 (2022-05-26)
+**Bugfixes**
+
+- When changing a regular worker to an irregular worker via the wizard, no longer
+  give an error when their (former) shift is full. (`#390 <https://github.com/beescoop/obeesdoo/issues/390>`_)
+
+
 12.0.1.1.1 (2022-05-26)
 **Bugfixes**
 

--- a/beesdoo_shift/__manifest__.py
+++ b/beesdoo_shift/__manifest__.py
@@ -9,7 +9,7 @@
     "author": "Thibault Francois, Elouan Le Bars, Coop IT Easy SCRLfs",
     "website": "https://github.com/beescoop/Obeesdoo",
     "category": "Cooperative management",
-    "version": "12.0.1.1.3",
+    "version": "12.0.1.1.4",
     "depends": ["mail"],
     "data": [
         "data/system_parameter.xml",

--- a/beesdoo_shift/readme/HISTORY.rst
+++ b/beesdoo_shift/readme/HISTORY.rst
@@ -1,3 +1,10 @@
+12.0.1.1.4 (2022-05-26)
+**Bugfixes**
+
+- When changing a regular worker to an irregular worker via the wizard, no longer
+  give an error when their (former) shift is full. (`#390 <https://github.com/beescoop/obeesdoo/issues/390>`_)
+
+
 12.0.1.1.1 (2022-05-26)
 **Bugfixes**
 

--- a/beesdoo_shift/readme/newsfragments/390.bugfix.rst
+++ b/beesdoo_shift/readme/newsfragments/390.bugfix.rst
@@ -1,0 +1,2 @@
+When changing a regular worker to an irregular worker via the wizard, no longer
+give an error when their (former) shift is full.

--- a/beesdoo_shift/readme/newsfragments/390.bugfix.rst
+++ b/beesdoo_shift/readme/newsfragments/390.bugfix.rst
@@ -1,2 +1,0 @@
-When changing a regular worker to an irregular worker via the wizard, no longer
-give an error when their (former) shift is full.

--- a/beesdoo_shift/static/description/index.html
+++ b/beesdoo_shift/static/description/index.html
@@ -372,19 +372,19 @@ ul.auto-toc {
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#configuration" id="id2">Configuration</a></li>
-<li><a class="reference internal" href="#changelog" id="id3">Changelog</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id4">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id5">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id6">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id7">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id8">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="id3">Configuration</a></li>
+<li><a class="reference internal" href="#changelog" id="id4">Changelog</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id5">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id6">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id7">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id8">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id9">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
 <div class="section" id="configuration">
-<h1><a class="toc-backref" href="#id2">Configuration</a></h1>
+<h1><a class="toc-backref" href="#id3">Configuration</a></h1>
 <ul class="simple">
 <li>Translate cooperative status selection field, the terms to translate are:<ul>
 <li>shift_status_up_to_date,</li>
@@ -404,7 +404,13 @@ ul.auto-toc {
 </ul>
 </div>
 <div class="section" id="changelog">
-<h1><a class="toc-backref" href="#id3">Changelog</a></h1>
+<h1><a class="toc-backref" href="#id4">Changelog</a></h1>
+<p>12.0.1.1.4 (2022-05-26)
+<strong>Bugfixes</strong></p>
+<ul class="simple">
+<li>When changing a regular worker to an irregular worker via the wizard, no longer
+give an error when their (former) shift is full. (<a class="reference external" href="https://github.com/beescoop/obeesdoo/issues/390">#390</a>)</li>
+</ul>
 <p>12.0.1.1.1 (2022-05-26)
 <strong>Bugfixes</strong></p>
 <ul class="simple">
@@ -413,7 +419,7 @@ wizard. (<a class="reference external" href="https://github.com/beescoop/obeesdo
 </ul>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id4">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id5">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/beescoop/obeesdoo/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -421,9 +427,9 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id5">Credits</a></h1>
+<h1><a class="toc-backref" href="#id6">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id6">Authors</a></h2>
+<h2><a class="toc-backref" href="#id7">Authors</a></h2>
 <ul class="simple">
 <li>Thibault Francois</li>
 <li>Elouan Le Bars</li>
@@ -431,14 +437,14 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id7">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id8">Contributors</a></h2>
 <ul class="simple">
 <li>Beescoop - Cellule IT</li>
 <li>Coop IT Easy SCRLfs</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id8">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id9">Maintainers</a></h2>
 <p>This module is part of the <a class="reference external" href="https://github.com/beescoop/obeesdoo/tree/12.0/beesdoo_shift">beescoop/obeesdoo</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>

--- a/beesdoo_shift/wizard/subscribe.py
+++ b/beesdoo_shift/wizard/subscribe.py
@@ -138,7 +138,11 @@ class Subscribe(models.TransientModel):
     @api.multi
     def subscribe(self):
         self = self._check()
-        if self.shift_id and self.shift_id.remaining_worker <= 0:
+        if (
+            self.shift_id
+            and self.working_mode == "regular"
+            and self.shift_id.remaining_worker <= 0
+        ):
             raise UserError(_("There is no remaining spot in this shift"))
 
         # cleanup previous shift template subscriptions


### PR DESCRIPTION


## Description

Previously the error would be shown when changing a regular worker to an
irregular worker, because the `shift_id` field was not erased.

## Odoo task (if applicable)

https://gestion.coopiteasy.be/web#view_type=form&model=project.task&id=8482&active_id=8482&menu_id=

## Checklist before approval

- [ ] Tests are present (or not needed).
- [ ] Credits/copyright have been changed correctly.
- [ ] (If a new module) Moving this to OCA has been considered.
