### PR TITLE
[FIX] beesdoo_shift_attendance: remove has_accounting entries

### DIFF
--- a/beesdoo_shift_attendance/views/res_config_settings_view.xml
+++ b/beesdoo_shift_attendance/views/res_config_settings_view.xml
@@ -22,7 +22,6 @@
                         data-key="beesdoo_shift"
                         groups="beesdoo_shift.group_cooperative_admin"
                     >
-                        <field name="has_accounting_entries" invisible="1" />
                         <h2>Attendance Sheets</h2>
                         <div class="row mt16 o_settings_container">
                             <div class="col-xs-12 col-md-6 o_setting_box">


### PR DESCRIPTION
Breaks the update after module splits. The field is not
displayed nor used in the inheriting view

