### PR TITLE
[FIX] beesdoo_product: main_seller_id search

### DIFF
--- a/beesdoo_product/readme/newsfragments/459.bugfix.rst
+++ b/beesdoo_product/readme/newsfragments/459.bugfix.rst
@@ -1,0 +1,1 @@
+Fix searching Main Seller ID and storing that value in the database.

--- a/beesdoo_product/tests/__init__.py
+++ b/beesdoo_product/tests/__init__.py
@@ -1,2 +1,3 @@
+from . import test_main_seller_id
 from . import test_search_main_seller_product_code
 from . import test_suggested_price

--- a/beesdoo_product/tests/test_main_seller_id.py
+++ b/beesdoo_product/tests/test_main_seller_id.py
@@ -1,0 +1,41 @@
+# Copyright 2021 Coop IT Easy SCRL fs
+#   Rémy Taymans <remy@coopiteasy.be>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+import datetime
+
+from odoo.tests import TransactionCase
+
+
+class TestMainSeller(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.product1 = self.env.ref("product.product_delivery_01")
+        self.product2 = self.env.ref("product.product_delivery_02")
+        self.product3 = self.env.ref("product.product_product_6")
+        self.product1_main_supplierinfo_id = self.product1.seller_ids[0]
+        self.product2_main_supplierinfo_id = self.product2.seller_ids[-1]
+
+        # Set the first supplierinfo as the most recent one
+        for index, sup in enumerate(self.product1.seller_ids):
+            sup.date_start = datetime.date.today() - datetime.timedelta(weeks=index)
+        # Set the last supplierinfo as the most recent one
+        for index, sup in enumerate(self.product2.seller_ids):
+            sup.date_start = datetime.date.today() + datetime.timedelta(weeks=index)
+        # Remove all supplierinfo
+        self.product3.seller_ids = False
+
+    def test_get_main_suppplierinfo(self):
+        """
+        Check that the main supplierinfo is the most recent one.
+        """
+        self.assertEqual(
+            self.product1.product_tmpl_id._get_main_supplier_info(),
+            self.product1_main_supplierinfo_id,
+        )
+        self.assertEqual(
+            self.product2.product_tmpl_id._get_main_supplier_info(),
+            self.product2_main_supplierinfo_id,
+        )
+        self.assertFalse(self.product3.product_tmpl_id._get_main_supplier_info())
+        self.assertFalse(self.product3.product_tmpl_id._get_main_supplier_info().price)

--- a/beesdoo_product/tests/test_search_main_seller_product_code.py
+++ b/beesdoo_product/tests/test_search_main_seller_product_code.py
@@ -27,7 +27,7 @@ class TestSearchMainSellerProductCode(TransactionCase):
                 (
                     "main_seller_id_product_code",
                     "=",
-                    self.product1.top_supplierinfo_id.product_code,
+                    self.product1.main_supplierinfo_id.product_code,
                 )
             ]
         )
@@ -37,7 +37,7 @@ class TestSearchMainSellerProductCode(TransactionCase):
                 (
                     "main_seller_id_product_code",
                     "=",
-                    self.product2.top_supplierinfo_id.product_code,
+                    self.product2.main_supplierinfo_id.product_code,
                 )
             ]
         )


### PR DESCRIPTION
## Description

The Main Seller can't be sorted in tree view and also the value of the column `main_seller_id` in the database is not updated anymore, causing issue to external tools that rely on this column.

## Odoo task (if applicable)

[task](https://gestion.coopiteasy.be/web#id=9305&model=project.task&view_type=form&menu_id=)

## Checklist before approval

- [x] Tests are present (or not needed).
- [x] Credits/copyright have been changed correctly.
- [x] Change log snippet is present.
- [x] (If a new module) Moving this to OCA has been considered.
