### PR TITLE
[FIX] cooperator_worker: remove auto_install

### DIFF
--- a/cooperator_worker/__manifest__.py
+++ b/cooperator_worker/__manifest__.py
@@ -12,7 +12,6 @@
     "data": [
         "views/product_template_views.xml",
     ],
-    "auto_install": True,
     "demo": ["demo/product_share.xml"],
     "license": "AGPL-3",
 }


### PR DESCRIPTION
auto_install was added during the migration. It is a regression as both cooperator and beesdoo_shift modules can be used separately. Making the link is a choice by the user.
