### PR TITLE
[IMP] [eater_]member_card: Do not set barcode on eaters

### DIFF
--- a/eater_member_card/__manifest__.py
+++ b/eater_member_card/__manifest__.py
@@ -11,7 +11,7 @@
     "summary": "Compute barcode based on eaters",
     "website": "https://github.com/beescoop/Obeesdoo",
     "category": "Sales",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.1.0",
     "depends": ["eater", "member_card"],
     "data": [
         "views/partner.xml",

--- a/eater_member_card/migrations/12.0.1.1.0/post-migration.py
+++ b/eater_member_card/migrations/12.0.1.1.0/post-migration.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2022 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import logging
+
+from openupgradelib import openupgrade
+
+_logger = logging.getLogger(__name__)
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    _logger.info("recomputing barcode on partner")
+    env["res.partner"].search([])._compute_bar_code()

--- a/eater_member_card/models/partner.py
+++ b/eater_member_card/models/partner.py
@@ -9,20 +9,21 @@ class Partner(models.Model):
 
     @api.multi
     @api.depends(
-        "parent_eater_id",
-        "parent_eater_id.barcode",
         "eater",  # cf comment hereunder
         "member_card_ids",
     )
     def _compute_bar_code(self):
-        parents = self.filtered(lambda p: not p.parent_eater_id)
-        eaters = self.filtered(lambda p: p.parent_eater_id)
-        super(Partner, parents)._compute_bar_code()
+        super()._compute_bar_code()
 
+        eaters = self.filtered(lambda p: p.parent_eater_id)
         # warning : there is not constraint checking that parent_eater_id
         # is set if eater field is set to eater
         for partner in eaters:
-            partner.barcode = partner.parent_eater_id.barcode
+            # Eaters must not have a barcode set. This should already be
+            # implicitly true, but let's make it explicit.
+            #
+            # Eaters should use their parent's barcode.
+            partner.barcode = False
 
     @api.multi
     def _new_eater(self, surname, name, email):

--- a/eater_member_card/readme/newsfragments/477.bugfix.rst
+++ b/eater_member_card/readme/newsfragments/477.bugfix.rst
@@ -1,0 +1,2 @@
+Revert change: Eaters no longer share their parent's barcode. Instead, their
+barcode is now undefined (i.e. no barcode).

--- a/member_card/models/partner.py
+++ b/member_card/models/partner.py
@@ -23,6 +23,8 @@ class Partner(models.Model):
                 for c in partner.member_card_ids:
                     if c.valid:
                         partner.barcode = c.barcode
+            else:
+                partner.barcode = False
 
     @api.multi
     def _deactivate_active_cards(self):


### PR DESCRIPTION


## Description

This reverts a change made in 9696118a600c37f0b0ca95b6d31f574246573ee0, PR #289.


## Odoo task (if applicable)

https://gestion.coopiteasy.be/web#id=9490&model=project.task&view_type=form&menu_id=

## Checklist before approval

- [ ] Tests are present (or not needed).
- [ ] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [ ] (If a new module) Moving this to OCA has been considered.
