### PR TITLE
[FIX] barcode rule priority

### DIFF
--- a/product_barcode_generator/data/barcode_rule.xml
+++ b/product_barcode_generator/data/barcode_rule.xml
@@ -6,7 +6,7 @@
             <field name="barcode_nomenclature_id">1</field>
             <field name="type">product</field>
             <field name="pattern">043</field>
-            <field name="sequence">45</field>
+            <field name="sequence">9</field>
             <field name="encoding">ean13</field>
         </record>
     </data>


### PR DESCRIPTION
beesdoo_barcode_rule which was high on the priorities, it has been replaced by a new rule with sequence=45. This resulted in error because another rule with higher priority was used instead. Therefore we increase the priority of this rule.

This can only be tested on new DB because the record has noupdate.
## Description



## Odoo task (if applicable)



## Checklist before approval

- [ ] Tests are present (or not needed).
- [ ] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [ ] (If a new module) Moving this to OCA has been considered.
