### PR TITLE
12.0 [ADD] supercoop info permission

### DIFF
--- a/beesdoo_website_shift/__manifest__.py
+++ b/beesdoo_website_shift/__manifest__.py
@@ -18,6 +18,8 @@
     "data": [
         "data/res_config_data.xml",
         "views/shift_website_templates.xml",
+        "views/portal_website_templates.xml",
+        "views/res_partner_views.xml",
         "views/my_shift_website_templates.xml",
         "views/res_config_views.xml",
         "views/assets.xml",

--- a/beesdoo_website_shift/__manifest__.py
+++ b/beesdoo_website_shift/__manifest__.py
@@ -11,7 +11,7 @@
     """,
     "author": "Coop IT Easy SC",
     "license": "AGPL-3",
-    "version": "12.0.2.1.1",
+    "version": "12.0.2.2.0",
     "website": "https://github.com/beescoop/Obeesdoo",
     "category": "Cooperative management",
     "depends": ["portal", "website", "shift"],

--- a/beesdoo_website_shift/controllers/__init__.py
+++ b/beesdoo_website_shift/controllers/__init__.py
@@ -1,1 +1,2 @@
 from . import main
+from . import portal

--- a/beesdoo_website_shift/controllers/portal.py
+++ b/beesdoo_website_shift/controllers/portal.py
@@ -1,0 +1,22 @@
+from odoo.http import request
+
+from odoo.addons.portal.controllers.portal import CustomerPortal
+
+
+class WorkerPortalAccount(CustomerPortal):
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+        if "OPTIONAL_BILLING_FIELDS" not in vars(self):
+            self.OPTIONAL_BILLING_FIELDS = CustomerPortal.OPTIONAL_BILLING_FIELDS.copy()
+        self.OPTIONAL_BILLING_FIELDS.extend(["share_supercoop_info"])
+
+    def _prepare_portal_layout_values(self):
+        values = super()._prepare_portal_layout_values()
+        partner = request.env.user.partner_id
+        values.update(
+            {
+                "super": partner.super,
+                "share_supercoop_info": partner.share_supercoop_info,
+            }
+        )
+        return values

--- a/beesdoo_website_shift/controllers/portal.py
+++ b/beesdoo_website_shift/controllers/portal.py
@@ -1,4 +1,5 @@
 from odoo.http import request
+from odoo import http
 
 from odoo.addons.portal.controllers.portal import CustomerPortal
 
@@ -20,3 +21,14 @@ class WorkerPortalAccount(CustomerPortal):
             }
         )
         return values
+
+    @http.route(["/my/account"], type="http", auth="user", website=True)
+    def account(self, redirect=None, **post):
+        if post and request.httprequest.method == 'POST':
+            if "share_supercoop_info" in post:
+                post["share_supercoop_info"] = True
+            else:
+                post["share_supercoop_info"] = False
+        res = super().account(redirect, **post)
+        return res
+

--- a/beesdoo_website_shift/controllers/portal.py
+++ b/beesdoo_website_shift/controllers/portal.py
@@ -1,5 +1,5 @@
-from odoo.http import request
 from odoo import http
+from odoo.http import request
 
 from odoo.addons.portal.controllers.portal import CustomerPortal
 
@@ -24,11 +24,10 @@ class WorkerPortalAccount(CustomerPortal):
 
     @http.route(["/my/account"], type="http", auth="user", website=True)
     def account(self, redirect=None, **post):
-        if post and request.httprequest.method == 'POST':
+        if post and request.httprequest.method == "POST":
             if "share_supercoop_info" in post:
                 post["share_supercoop_info"] = True
             else:
                 post["share_supercoop_info"] = False
         res = super().account(redirect, **post)
         return res
-

--- a/beesdoo_website_shift/migrations/12.0.2.2.0/post-set_share_supercoop_info.py
+++ b/beesdoo_website_shift/migrations/12.0.2.2.0/post-set_share_supercoop_info.py
@@ -1,0 +1,10 @@
+# Copyright 2023 Coop IT Easy SC
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+def migrate(cr, version):
+    # before this version, the module behaved as if then new
+    # share_supercoop_info field was true. the default value of the field is
+    # false, but the behavior must not change for databases that were already
+    # using this module.
+    cr.execute("update res_partner set share_supercoop_info = true where super")

--- a/beesdoo_website_shift/models/__init__.py
+++ b/beesdoo_website_shift/models/__init__.py
@@ -1,2 +1,3 @@
 from . import res_config
 from . import website
+from . import res_partner

--- a/beesdoo_website_shift/models/res_partner.py
+++ b/beesdoo_website_shift/models/res_partner.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    share_supercoop_info = fields.Boolean(
+        string="Accept to share my info as Supercoop",
+        default=True,
+    )

--- a/beesdoo_website_shift/models/res_partner.py
+++ b/beesdoo_website_shift/models/res_partner.py
@@ -6,5 +6,5 @@ class ResPartner(models.Model):
 
     share_supercoop_info = fields.Boolean(
         string="Accept to share my info as Supercoop",
-        default=True,
+        default=False,
     )

--- a/beesdoo_website_shift/views/my_shift_website_templates.xml
+++ b/beesdoo_website_shift/views/my_shift_website_templates.xml
@@ -201,7 +201,7 @@
                     <button
                         type="button"
                         class="btn btn-default btn-sm ml-2 pull-right"
-                        t-if="shift.super_coop_id.name"
+                        t-if="shift.super_coop_id.name and shift.super_coop_id.share_supercoop_info"
                         data-toggle="modal"
                         t-att-data-target="'#super_coop-shift-%s' % shift_index"
                     >

--- a/beesdoo_website_shift/views/portal_website_templates.xml
+++ b/beesdoo_website_shift/views/portal_website_templates.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <template
-        id="website_portal_restrict_my_details"
+        id="portal_my_details"
         name="Website Portal Restrict Modification"
         inherit_id="portal.portal_my_details"
     >
@@ -25,6 +25,25 @@
                     >Accept to share my info
                         as Supercoop</label>
                 </div>
+            </t>
+        </xpath>
+    </template>
+
+    <template
+        id="portal_layout"
+        name="Website Portal Details Form"
+        inherit_id="portal.portal_layout"
+    >
+        <xpath expr="//div[hasclass('o_portal_my_details')]" position="after">
+            <t t-if='super'>
+                <p class="text-center">
+                    <span t-if="share_supercoop_info">
+                        I accept to share my info as Supercoop
+                    </span>
+                    <span t-if="not share_supercoop_info">
+                        I do not accept to share my info as Supercoop
+                    </span>
+                </p>
             </t>
         </xpath>
     </template>

--- a/beesdoo_website_shift/views/portal_website_templates.xml
+++ b/beesdoo_website_shift/views/portal_website_templates.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template
+        id="website_portal_restrict_my_details"
+        name="Website Portal Restrict Modification"
+        inherit_id="portal.portal_my_details"
+    >
+        <xpath expr="//select[@name='state_id']/.." position="after">
+            <t t-if='super'>
+                <div
+                    class="form-check"
+                    t-attf-class="form-group #{error.get('share_supercoop_info') and 'o_has_error' or ''} col-xl-6"
+                >
+                    <input
+                        type="checkbox"
+                        name="share_supercoop_info"
+                        class="form-check-input"
+                        t-att-checked="share_supercoop_info"
+                        t-attf-class="#{error.get('share_supercoop_info') and 'is-invalid' or ''}"
+                    >
+                    </input>
+                    <label
+                        class="col-form-label"
+                        for="share_supercoop_info"
+                    >Accept to share my info
+                        as Supercoop</label>
+                </div>
+            </t>
+        </xpath>
+    </template>
+
+</odoo>

--- a/beesdoo_website_shift/views/res_partner_views.xml
+++ b/beesdoo_website_shift/views/res_partner_views.xml
@@ -3,10 +3,7 @@
 
     <record id="view_res_partner_form" model="ir.ui.view">
         <field name="model">res.partner</field>
-        <field
-            name="inherit_id"
-            ref="beesdoo_shift.super_coop_partner_inherited_view_form"
-        />
+        <field name="inherit_id" ref="shift.super_coop_partner_inherited_view_form" />
         <field name="arch" type="xml">
             <field name="super" position="after">
                 <field

--- a/beesdoo_website_shift/views/res_partner_views.xml
+++ b/beesdoo_website_shift/views/res_partner_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+
+    <record id="view_res_partner_form" model="ir.ui.view">
+        <field name="model">res.partner</field>
+        <field
+            name="inherit_id"
+            ref="beesdoo_shift.super_coop_partner_inherited_view_form"
+        />
+        <field name="arch" type="xml">
+            <field name="super" position="after">
+                <field
+                    name="share_supercoop_info"
+                    attrs="{'invisible': [('super', '=', False)]}"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION


## Description

Add an option for supercoop to hide the button that displays their info on the shift portal. 


## Odoo task (if applicable)

https://gestion.coopiteasy.be/web#id=9465&model=project.task&view_type=form&menu_id=

## Checklist before approval

- [ ] Tests are present (or not needed).
- [ ] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [ ] (If a new module) Moving this to OCA has been considered.
