### PR TITLE
[12.0][FIX] fix penalty setting resetting on update

### DIFF
--- a/shift_worker_status/data/data.xml
+++ b/shift_worker_status/data/data.xml
@@ -1,7 +1,20 @@
 <?xml version="1.0" ?>
 <odoo>
     <data noupdate="1">
-         <record id="param_config_irregular_penalty" model="ir.config_parameter">
+        <!--
+            when this parameter is set to false, the ir.config_parameter is
+            deleted, along with its corresponding ir.model.data record. this
+            normally causes this record to be re-created when updating the
+            module, even though it is set as noupdate, because it is seen as
+            new data, effectively resetting the value to true. the forcecreate
+            property set to false ensures that this record is not recreated on
+            module update.
+        -->
+        <record
+            id="param_config_irregular_penalty"
+            model="ir.config_parameter"
+            forcecreate="false"
+        >
             <field name="key">shift_worker_status.irregular_penalty</field>
             <field name="value">True</field>
         </record>


### PR DESCRIPTION
## description

fix `shift_worker_status.irregular_penalty` config parameter resetting to true when updating the module.

## odoo task

[t10727](https://gestion.coopiteasy.be/web#id=10727&model=project.task)