### PR TITLE
[FIX] beesdoo_shift_swap: Prevent a skip of subsequent items

### DIFF
--- a/beesdoo_shift_swap/models/planning.py
+++ b/beesdoo_shift_swap/models/planning.py
@@ -43,14 +43,13 @@ class TaskTemplate(models.Model):
 
         swap_subscription_done = []
         for shift in shifts:
-            for rec in list(changes):
-                shift, swap_subscription_done, done = rec.update_shift_data(
-                    shift, swap_subscription_done
-                )
-                if done:
-                    # You're not supposed to remove items from a list while
-                    # looping over it. We circumvent this problem by looping
-                    # over a copy of the list, which will not be affected.
-                    changes.remove(rec)
+            # process the remaining changes and create a new list containing
+            # only the changes that have not be processed yet.
+            changes = [
+                rec
+                for rec in changes
+                # 3rd returned element is a boolean telling whether it was done
+                if not rec.update_shift_data(shift, swap_subscription_done)[2]
+            ]
 
         return shifts

--- a/beesdoo_shift_swap/models/planning.py
+++ b/beesdoo_shift_swap/models/planning.py
@@ -43,11 +43,14 @@ class TaskTemplate(models.Model):
 
         swap_subscription_done = []
         for shift in shifts:
-            for rec in changes:
+            for rec in list(changes):
                 shift, swap_subscription_done, done = rec.update_shift_data(
                     shift, swap_subscription_done
                 )
                 if done:
+                    # You're not supposed to remove items from a list while
+                    # looping over it. We circumvent this problem by looping
+                    # over a copy of the list, which will not be affected.
                     changes.remove(rec)
 
         return shifts


### PR DESCRIPTION
## Description

Modifying a list while looping over it is not allowed. It causes subsequent items to be skipped.

I suspect that this is the cause of a bug where a person who wants to swap a shift is correctly unsubscribed from their old shift, but not subscribed to their new shift. But I have not been able to verify this.

It is not clear to me why this code exists.

## Odoo task (if applicable)

[T12851](https://gestion.coopiteasy.be/web#id=12842&model=project.task&view_type=form&menu_id=)

## Checklist before approval

- [ ] Tests are present (or not needed).
- [ ] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [ ] (If a new module) Moving this to OCA has been considered.
