### PR TITLE
[12.0][FIX] shift: Recompute partner's can_shop when dependencies change

### DIFF
--- a/shift/models/res_partner.py
+++ b/shift/models/res_partner.py
@@ -88,7 +88,7 @@ class ResPartner(models.Model):
         store=True,
     )
 
-    @api.depends("cooperative_status_ids")
+    @api.depends("cooperative_status_ids.can_shop")
     def _compute_can_shop(self):
         """
         Shopping authorisation may vary on the can_shop status of the

--- a/shift/readme/newsfragments/535.bugfix.rst
+++ b/shift/readme/newsfragments/535.bugfix.rst
@@ -1,0 +1,2 @@
+Correctly recompute ``can_shop`` on partner when the value changes in the
+``cooperative_status``.


### PR DESCRIPTION
## Description

Because `can_shop` is a stored computed field, this was previously broken. It wouldn't change, because `cooperative_status_ids` always remains identical---a single record.

## Odoo task (if applicable)

T13157

## Checklist before approval

- [ ] Tests are present (or not needed).
- [ ] Credits/copyright have been changed correctly.
- [x] Change log snippet is present.
- [ ] (If a new module) Moving this to OCA has been considered.
