### PR TITLE
[FIX] set PO line name with onchange_product_id

### DIFF
--- a/purchase_order_generator/models/purchase_order_generator.py
+++ b/purchase_order_generator/models/purchase_order_generator.py
@@ -138,6 +138,7 @@ class PurchaseOrderGenerator(models.Model):
                         "date_planned": self.date_planned,
                     }
                 )
+                pol.onchange_product_id()
                 pol.compute_taxes_id()
 
             self.generated_purchase_order_ids += purchase_order

--- a/purchase_order_generator/models/purchase_order_generator_line.py
+++ b/purchase_order_generator/models/purchase_order_generator_line.py
@@ -14,7 +14,7 @@ class PurchaseOrderGeneratorLine(models.Model):
     _description = "Purchase Order Generator Line"
     _name = "purchase.order.generator.line"
 
-    name = fields.Char(string="Product Name", compute="_compute_name")
+    name = fields.Char(string="Product Name", related="product_template_id.name")
     cpo_id = fields.Many2one(
         comodel_name="purchase.order.generator",
         string="Purchase Order Generator",
@@ -94,18 +94,6 @@ class PurchaseOrderGeneratorLine(models.Model):
     subtotal = fields.Float(
         string="Subtotal (w/o VAT)", compute="_compute_coverage_and_subtotal"
     )
-
-    @api.multi
-    @api.depends("supplierinfo_id")
-    def _compute_name(self):
-        for cpol in self:
-            if cpol.supplierinfo_id and cpol.supplierinfo_id.product_code:
-                product_code = cpol.supplierinfo_id.product_code
-                product_name = cpol.product_template_id.name
-                cpol_name = "[{}] {}".format(product_code, product_name)
-            else:
-                cpol_name = cpol.product_template_id.name
-            cpol.name = cpol_name
 
     @api.multi
     @api.onchange("product_template_id")


### PR DESCRIPTION
## Description
This will set the correct description on the line based on supplierinfo product_name. 
- currently the product template name is used, instead of supplierinfo.product_name 
- the computation of the name is doing what Odoo is already doing, let's remove it and let Odoo compute the description when creating the PO line. 

I don't know why precommit fails but it's not due to the new code. It runs fine locally. 

## Odoo task (if applicable)
https://gestion.coopiteasy.be/web#view_type=form&model=project.task&id=13567&active_id=13567&menu_id=


## Checklist before approval

- [ ] Tests are present (or not needed).
- [ ] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [ ] (If a new module) Moving this to OCA has been considered.
