### PR TITLE
[FIX] pos_shift_partner_can_shop: popup does not show

### DIFF
--- a/pos_shift_partner_can_shop/static/src/js/ActionpadWidget.esm.js
+++ b/pos_shift_partner_can_shop/static/src/js/ActionpadWidget.esm.js
@@ -14,10 +14,10 @@ const ActionpadWidgetConfirm = () =>
             super.setup(...arguments);
         }
 
-        async trigger() {
+        async trigger(event_name) {
             const customer_partner = this.env.pos.get_order().get_partner();
             if (
-                this.props.actionName.valueOf() === "Payment" &&
+                event_name === "click-pay" &&
                 customer_partner &&
                 !customer_partner.can_shop
             ) {


### PR DESCRIPTION
Using actionName is not correct because it is subject to languages changes. If language is set to something else than English then this test will fail.

A side effect, is that clicking of the "Select partner" button does not distinguish from clicking of the "Payment" button with such a test.

The right way is to get event_name that comes as the first argument of the `trigger` method.

## Description



## Odoo task (if applicable)



## Checklist before approval

- [ ] Tests are present (or not needed).
- [ ] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [ ] (If a new module) Moving this to OCA has been considered.
