### PR TITLE
[16.0][ADD] volunteer: add generators and subscriptions automation

### DIFF
--- a/volunteer/models/volunteer_shift_recurrent_generator.py
+++ b/volunteer/models/volunteer_shift_recurrent_generator.py
@@ -81,12 +81,14 @@ class VolunteerShiftRecurrentGenerator(models.Model):
     ]
 
     # Override methods
+
     @api.model_create_multi
     def create(self, vals_list):
         generators = super().create(vals_list)
         for generator in generators:
             if generator.state == "confirmed":
                 generator._generate_shifts()
+                generator._generate_all_participation()
         return generators
 
     def write(self, vals):
@@ -94,9 +96,10 @@ class VolunteerShiftRecurrentGenerator(models.Model):
         res = super().write(vals)
         for generator in self:
             previous_state = old_states[generator.id]
-            # If the generator is confirmed, generate shifts
+            # If the generator is confirmed, generate shifts and participation
             if previous_state == "draft" and generator.state == "confirmed":
                 generator._generate_shifts()
+                generator._generate_all_participation()
         return res
 
     # Methods
@@ -166,3 +169,8 @@ class VolunteerShiftRecurrentGenerator(models.Model):
             shift_generated_start_time += delta
             shift_generated_end_time += delta
             nb_generated_shift += 1
+
+    def _generate_all_participation(self):
+        """Generate participation for all subscriptions in the generator"""
+        for subscription in self.volunteer_subscription_ids:
+            subscription.generate_participation()

--- a/volunteer/models/volunteer_shift_recurrent_generator.py
+++ b/volunteer/models/volunteer_shift_recurrent_generator.py
@@ -86,6 +86,11 @@ class VolunteerShiftRecurrentGenerator(models.Model):
     def create(self, vals_list):
         generators = super().create(vals_list)
         for generator in generators:
+            # Prevent creating generators directly in canceled state
+            if generator.state == "canceled":
+                raise ValidationError(
+                    _("A generator cannot be created in canceled state.")
+                )
             if generator.state == "confirmed":
                 generator._generate_shifts()
                 generator._generate_all_participation()
@@ -96,10 +101,11 @@ class VolunteerShiftRecurrentGenerator(models.Model):
         res = super().write(vals)
         for generator in self:
             previous_state = old_states[generator.id]
-            # If the generator is confirmed, generate shifts and participation
             if previous_state == "draft" and generator.state == "confirmed":
                 generator._generate_shifts()
                 generator._generate_all_participation()
+            elif previous_state != "canceled" and generator.state == "canceled":
+                generator._handle_generator_cancellation()
         return res
 
     # Methods
@@ -117,6 +123,33 @@ class VolunteerShiftRecurrentGenerator(models.Model):
             return relativedelta(years=self.interval)
         else:
             raise UserError(_("The interval type is not valid."))
+
+    def _get_active_subscriptions(self):
+        """Get all active subscriptions for this generator."""
+        self.ensure_one()
+        today = fields.Date.today()
+        active_subscriptions = self.volunteer_subscription_ids.filtered(
+            lambda subscription: subscription.start_date <= today
+            and (not subscription.end_date or subscription.end_date >= today)
+        )
+        return active_subscriptions
+
+    def _get_future_subscriptions(self):
+        """Get all future subscriptions for this generator."""
+        self.ensure_one()
+        today = fields.Date.today()
+        future_subscriptions = self.volunteer_subscription_ids.filtered(
+            lambda subscription: subscription.start_date >= today
+        )
+        return future_subscriptions
+
+    def _get_future_shifts(self):
+        """Get all future shifts for this generator."""
+        self.ensure_one()
+        today = fields.Date.today()
+        return self.volunteer_shift_ids.filtered(
+            lambda shift: shift.start_time.date() >= today
+        )
 
     def _generate_shifts(self):
         """Generate all shifts from the generator start date
@@ -174,3 +207,26 @@ class VolunteerShiftRecurrentGenerator(models.Model):
         """Generate participation for all subscriptions in the generator"""
         for subscription in self.volunteer_subscription_ids:
             subscription.generate_participation()
+
+    def _handle_generator_cancellation(self):
+        """Handle the cancellation of the generator by:
+        - Setting the end_date of all future subscriptions to today
+        - Auto-canceling all future shifts
+        - Setting the generator until_date to today
+        """
+        self.ensure_one()
+        today = fields.Date.today()
+        active_subscriptions = self._get_active_subscriptions()
+        future_subscriptions = self._get_future_subscriptions()
+        subscriptions_to_canceled = active_subscriptions + future_subscriptions
+        subscriptions_to_canceled.write({"end_date": today})
+        # Auto-cancel future shifts, which will also cancel related participation
+        future_shifts = self._get_future_shifts()
+        future_shifts.write(
+            {"stage_id": self.env.ref("volunteer.volunteer_shift_stage_canceled").id}
+        )
+        # Set until_date to today using super to avoid write recursion
+        # (future validations will be added to write method
+        # and need to be bypassed)
+        res = super(VolunteerShiftRecurrentGenerator, self).write({"until_date": today})
+        return res

--- a/volunteer/models/volunteer_shift_recurrent_generator.py
+++ b/volunteer/models/volunteer_shift_recurrent_generator.py
@@ -8,6 +8,8 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import fields, models
 from odoo.exceptions import UserError
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
 from odoo.tools.translate import _
 
 
@@ -78,6 +80,25 @@ class VolunteerShiftRecurrentGenerator(models.Model):
         ),
     ]
 
+    # Override methods
+    @api.model_create_multi
+    def create(self, vals_list):
+        generators = super().create(vals_list)
+        for generator in generators:
+            if generator.state == "confirmed":
+                generator._generate_shifts()
+        return generators
+
+    def write(self, vals):
+        old_states = {generator.id: generator.state for generator in self}
+        res = super().write(vals)
+        for generator in self:
+            previous_state = old_states[generator.id]
+            # If the generator is confirmed, generate shifts
+            if previous_state == "draft" and generator.state == "confirmed":
+                generator._generate_shifts()
+        return res
+
     # Methods
 
     def _get_interval_delta(self):
@@ -93,3 +114,55 @@ class VolunteerShiftRecurrentGenerator(models.Model):
             return relativedelta(years=self.interval)
         else:
             raise UserError(_("The interval type is not valid."))
+
+    def _generate_shifts(self):
+        """Generate all shifts from the generator start date
+        until the generator until date or number of occurrences,
+        using the specified interval.
+        """
+        self.ensure_one()
+        nb_occurrence = self.company_id.shift_nb_occurrence
+        stage_confirmed = self.env.ref("volunteer.volunteer_shift_stage_confirmed")
+        delta = self._get_interval_delta()
+        today = fields.Date.today()
+        # Generate only future shifts
+        generation_start_date = (
+            today if self.start_time.date() < today else self.start_time.date()
+        )
+        # Calculate end date from until_date or occurrence count
+        if self.until_date:
+            generation_end_date = self.until_date
+        else:
+            generation_end_date = generation_start_date
+            for _i in range(nb_occurrence):
+                generation_end_date += delta
+        shift_generated_start_time = self.start_time
+        shift_generated_end_time = self.end_time
+        # Skip past occurrences by incrementing with delta until reaching a future date
+        while shift_generated_start_time.date() < today:
+            shift_generated_start_time += delta
+            shift_generated_end_time += delta
+        nb_generated_shift = 0
+        while (
+            nb_generated_shift < nb_occurrence
+            and shift_generated_start_time.date() <= generation_end_date
+        ):
+            self.env["volunteer.shift"].create(
+                {
+                    "name": self.name,
+                    "tz": self.tz,
+                    "start_time": shift_generated_start_time,
+                    "end_time": shift_generated_end_time,
+                    "max_volunteer_nb": self.max_volunteer_nb,
+                    "stage_id": stage_confirmed.id,
+                    "type_id": self.type_id.id,
+                    "category_id": self.category_id.id,
+                    "tag_ids": self.tag_ids.ids,
+                    "generator_id": self.id,
+                    "company_id": self.company_id.id,
+                    "coordinator_id": self.coordinator_id.id,
+                }
+            )
+            shift_generated_start_time += delta
+            shift_generated_end_time += delta
+            nb_generated_shift += 1

--- a/volunteer/models/volunteer_shift_recurrent_generator.py
+++ b/volunteer/models/volunteer_shift_recurrent_generator.py
@@ -6,10 +6,8 @@ from datetime import timedelta
 
 from dateutil.relativedelta import relativedelta
 
-from odoo import fields, models
-from odoo.exceptions import UserError
 from odoo import api, fields, models
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError
 from odoo.tools.translate import _
 
 
@@ -88,9 +86,7 @@ class VolunteerShiftRecurrentGenerator(models.Model):
         for generator in generators:
             # Prevent creating generators directly in canceled state
             if generator.state == "canceled":
-                raise ValidationError(
-                    _("A generator cannot be created in canceled state.")
-                )
+                raise UserError(_("A generator cannot be created in canceled state."))
             if generator.state == "confirmed":
                 generator._generate_shifts()
                 generator._generate_all_participation()

--- a/volunteer/models/volunteer_shift_recurrent_subscription.py
+++ b/volunteer/models/volunteer_shift_recurrent_subscription.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class VolunteerShiftRecurrentSubscription(models.Model):
@@ -43,3 +43,76 @@ class VolunteerShiftRecurrentSubscription(models.Model):
         store=True,
         readonly=True,
     )
+
+    # Override methods
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        subscriptions = super().create(vals_list)
+        for sub in subscriptions:
+            if sub.generator_id.state == "confirmed":
+                sub.generate_participation()
+        return subscriptions
+
+    # Methods
+
+    def generate_participation(self):
+        """Generate participation for all future shifts covered by this subscription.
+        This method cancels any conflicting punctual participation before generating
+        the recurrent participation.
+        """
+        self.ensure_one()
+        future_shifts = self._get_future_shifts_in_subscription_period()
+        self._cancel_conflicting_punctual_participation(future_shifts)
+        self._generate_participation_by_shifts(future_shifts)
+
+    def _get_future_shifts_in_subscription_period(self):
+        """Get all future shifts in the period defined by this subscription."""
+        self.ensure_one()
+        today = fields.Date.today()
+        shifts = self.generator_id.volunteer_shift_ids.filtered(
+            lambda shift: shift.start_time.date() >= today
+            and shift.start_time.date() >= self.start_date
+        )
+        if self.end_date:
+            shifts = shifts.filtered(
+                lambda shift: shift.end_time.date() <= self.end_date
+            )
+        return shifts
+
+    def _generate_participation_by_shifts(self, shifts):
+        """Generate participation records for the given shifts
+        for the volunteer linked to this subscription.
+        """
+        self.ensure_one()
+        participation_to_create = []
+        for shift in shifts:
+            participation_to_create.append(
+                {
+                    "shift_id": shift.id,
+                    "volunteer_id": self.volunteer_id.id,
+                    "registration_type": "recurrent",
+                    "registration_state": "confirmed",
+                }
+            )
+        self.env["volunteer.shift.participation"].create(participation_to_create)
+
+    def _cancel_conflicting_punctual_participation(self, shifts):
+        """Cancel the punctual participation of a volunteer if they subscribe
+        for a period when they already have punctual participation registered.
+        """
+        self.ensure_one()
+        all_participation_to_cancel = self.env["volunteer.shift.participation"].search(
+            [
+                ("shift_id", "in", shifts.ids),
+                ("volunteer_id", "=", self.volunteer_id.id),
+                ("registration_state", "=", "confirmed"),
+                ("registration_type", "!=", "recurrent"),
+            ]
+        )
+        if all_participation_to_cancel:
+            all_participation_to_cancel.write(
+                {
+                    "registration_state": "canceled",
+                }
+            )

--- a/volunteer/models/volunteer_shift_recurrent_subscription.py
+++ b/volunteer/models/volunteer_shift_recurrent_subscription.py
@@ -54,7 +54,40 @@ class VolunteerShiftRecurrentSubscription(models.Model):
                 sub.generate_participation()
         return subscriptions
 
+    def write(self, vals):
+        old_sub_data = {}
+        for sub in self:
+            old_sub_data[sub.id] = {
+                "start_date": sub.start_date,
+                "end_date": sub.end_date,
+                "generator_id": sub.generator_id.id,
+                "volunteer_id": sub.volunteer_id.id,
+            }
+        res = super().write(vals)
+        for sub in self:
+            old_sub = old_sub_data.get(sub.id)
+            sub._managing_cancel_or_create_participation(
+                old_sub.get("start_date"), old_sub.get("end_date")
+            )
+        return res
+
     # Methods
+
+    def _get_shifts_intersection_between_two_periods(
+        self, new_start_date, new_end_date, old_start_date, old_end_date
+    ):
+        """Get all shifts in the intersection between two periods."""
+        self.ensure_one()
+        intersection_start_date = max(new_start_date, old_start_date)
+        intersection_end_date = min(new_end_date, old_end_date)
+        if intersection_start_date > intersection_end_date:
+            # No intersection
+            return []
+        shifts_intersection = self.generator_id.volunteer_shift_ids.filtered(
+            lambda shift: shift.start_time.date() >= intersection_start_date
+            and shift.end_time.date() <= intersection_end_date
+        )
+        return shifts_intersection
 
     def generate_participation(self):
         """Generate participation for all future shifts covered by this subscription.
@@ -63,7 +96,6 @@ class VolunteerShiftRecurrentSubscription(models.Model):
         """
         self.ensure_one()
         future_shifts = self._get_future_shifts_in_subscription_period()
-        self._cancel_conflicting_punctual_participation(future_shifts)
         self._generate_participation_by_shifts(future_shifts)
 
     def _get_future_shifts_in_subscription_period(self):
@@ -85,6 +117,7 @@ class VolunteerShiftRecurrentSubscription(models.Model):
         for the volunteer linked to this subscription.
         """
         self.ensure_one()
+        self._cancel_conflicting_punctual_participation(shifts)
         participation_to_create = []
         for shift in shifts:
             participation_to_create.append(
@@ -96,6 +129,26 @@ class VolunteerShiftRecurrentSubscription(models.Model):
                 }
             )
         self.env["volunteer.shift.participation"].create(participation_to_create)
+
+    def _cancel_participation_by_shifts(self, shifts):
+        """Cancel all participation for given shifts
+        for the volunteer concerned by subscription in self.
+        """
+        self.ensure_one()
+        for shift in shifts:
+            participation_to_cancel = self.env["volunteer.shift.participation"].search(
+                [
+                    ("shift_id", "=", shift.id),
+                    ("volunteer_id", "=", self.volunteer_id.id),
+                    ("registration_state", "=", "confirmed"),
+                ]
+            )
+            if participation_to_cancel:
+                participation_to_cancel.write(
+                    {
+                        "registration_state": "canceled",
+                    }
+                )
 
     def _cancel_conflicting_punctual_participation(self, shifts):
         """Cancel the punctual participation of a volunteer if they subscribe
@@ -116,3 +169,68 @@ class VolunteerShiftRecurrentSubscription(models.Model):
                     "registration_state": "canceled",
                 }
             )
+
+    def _managing_cancel_or_create_participation(self, old_start_date, old_end_date):
+        """Manage the cancellation and generation of participation for the adequate periods.
+
+        The intersection between old and new subscription is an unchanged period.
+        New subscription areas outside of the intersection need participation to be generated.
+        Old subscription areas outside of the intersection need participation to be canceled.
+
+        Special case: if there is no intersection, all old participation need to be canceled
+        and new ones need to be generated.
+
+        Note: Cases of exact match between new and old subscriptions are not processed
+        since they mean there is no change requested.
+        """
+        self.ensure_one()
+        future_shifts = self.generator_id._get_future_shifts()
+        if not future_shifts:
+            return
+        new_end_date = self.end_date
+        new_start_date = self.start_date
+        date_last_shift = future_shifts.sorted("end_time", reverse=True)[
+            0
+        ].end_time.date()
+        if not new_end_date:
+            new_end_date = date_last_shift
+        if not old_end_date:
+            old_end_date = date_last_shift
+        shifts_intersection = self._get_shifts_intersection_between_two_periods(
+            new_start_date, new_end_date, old_start_date, old_end_date
+        )
+        if not shifts_intersection:
+            # No intersection : all old shifts need to be canceled
+            old_shifts = future_shifts.filtered(
+                lambda shift: shift.start_time.date() >= old_start_date
+                and shift.end_time.date() <= old_end_date
+            )
+            self._cancel_participation_by_shifts(old_shifts)
+            # All shifts covered by the new subscription need to be generated
+            # Call generate_participation on self, which is up to date
+            # since this management method is called after super().write()
+            self.generate_participation()
+        else:
+            # Define the boundaries of the full period between old and new subscription
+            start_date_full_period = min(new_start_date, old_start_date)
+            end_date_full_period = max(new_end_date, old_end_date)
+            # Filter the full period excluding the intersection period
+            shifts_full_period_without_intersection = future_shifts.filtered(
+                lambda shift: shift.start_time.date() >= start_date_full_period
+                and shift.end_time.date() <= end_date_full_period
+                and shift.id not in shifts_intersection.ids
+            )
+            # Filter the period of new subscription without intersection and in the full range
+            shifts_new_sub_only = shifts_full_period_without_intersection.filtered(
+                lambda shift: shift.start_time.date() >= new_start_date
+                and shift.end_time.date() <= new_end_date
+            )
+            # Generate participation for shifts newly covered by the subscription
+            self._generate_participation_by_shifts(shifts_new_sub_only)
+            # Filter the period of old subscription without intersection and in the full range
+            shifts_old_sub_only = shifts_full_period_without_intersection.filtered(
+                lambda shift: shift.start_time.date() >= old_start_date
+                and shift.end_time.date() <= old_end_date
+            )
+            # Cancel participation for shifts no longer covered by the subscription
+            self._cancel_participation_by_shifts(shifts_old_sub_only)

--- a/volunteer/models/volunteer_shift_recurrent_subscription.py
+++ b/volunteer/models/volunteer_shift_recurrent_subscription.py
@@ -91,8 +91,7 @@ class VolunteerShiftRecurrentSubscription(models.Model):
 
     def generate_participation(self):
         """Generate participation for all future shifts covered by this subscription.
-        This method cancels any conflicting punctual participation before generating
-        the recurrent participation.
+        Conflicting punctual participation is automatically canceled during generation.
         """
         self.ensure_one()
         future_shifts = self._get_future_shifts_in_subscription_period()
@@ -115,6 +114,8 @@ class VolunteerShiftRecurrentSubscription(models.Model):
     def _generate_participation_by_shifts(self, shifts):
         """Generate participation records for the given shifts
         for the volunteer linked to this subscription.
+        This method cancels any conflicting punctual participation before generating
+        the recurrent participation.
         """
         self.ensure_one()
         self._cancel_conflicting_punctual_participation(shifts)
@@ -151,8 +152,8 @@ class VolunteerShiftRecurrentSubscription(models.Model):
                 )
 
     def _cancel_conflicting_punctual_participation(self, shifts):
-        """Cancel the punctual participation of a volunteer if they subscribe
-        for a period when they already have punctual participation registered.
+        """Cancel all confirmed punctual participation on the given shifts
+        for this subscription's volunteer.
         """
         self.ensure_one()
         all_participation_to_cancel = self.env["volunteer.shift.participation"].search(

--- a/volunteer/tests/__init__.py
+++ b/volunteer/tests/__init__.py
@@ -9,3 +9,4 @@ from . import test_volunteer_shift
 from . import test_volunteer_shift_participation
 from . import test_volunteer_shift_recurrent_generator_generation
 from . import test_volunteer_recurrent_subscription_participation
+from . import test_volunteer_shift_recurrent_generator_cancellation

--- a/volunteer/tests/__init__.py
+++ b/volunteer/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_volunteer_generator_subscription_common
 from . import test_volunteer_shift
 from . import test_volunteer_shift_participation
 from . import test_volunteer_shift_recurrent_generator_generation
+from . import test_volunteer_recurrent_subscription_participation

--- a/volunteer/tests/__init__.py
+++ b/volunteer/tests/__init__.py
@@ -3,5 +3,8 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 from . import test_volunteer_common
+from . import test_volunteer_generator_subscription_common
+
 from . import test_volunteer_shift
 from . import test_volunteer_shift_participation
+from . import test_volunteer_shift_recurrent_generator_generation

--- a/volunteer/tests/__init__.py
+++ b/volunteer/tests/__init__.py
@@ -8,5 +8,5 @@ from . import test_volunteer_generator_subscription_common
 from . import test_volunteer_shift
 from . import test_volunteer_shift_participation
 from . import test_volunteer_shift_recurrent_generator_generation
-from . import test_volunteer_recurrent_subscription_participation
+from . import test_volunteer_shift_recurrent_subscription_participation
 from . import test_volunteer_shift_recurrent_generator_cancellation

--- a/volunteer/tests/test_volunteer_common.py
+++ b/volunteer/tests/test_volunteer_common.py
@@ -28,6 +28,7 @@ class TestVolunteerCommon(common.TransactionCase):
         self.Type = self.env["volunteer.shift.type"]
         self.Volunteer = self.env["volunteer.volunteer"]
         self.Participation = self.env["volunteer.shift.participation"]
+        self.Generator = self.env["volunteer.shift.recurrent.generator"]
 
         # Stages
         self.stage_confirmed = self.env.ref("volunteer.volunteer_shift_stage_confirmed")
@@ -54,7 +55,7 @@ class TestVolunteerCommon(common.TransactionCase):
         self.type1 = self.Type.create(
             {
                 "name": "TypeTest",
-                "description": "Type pour autotests",
+                "description": "Type for autotests",
             }
         )
 
@@ -92,7 +93,6 @@ class TestVolunteerCommon(common.TransactionCase):
                 "name": "VolunteerTest",
             }
         )
-
         # Create confirmed participation
         self.participation_confirmed = self.Participation.create(
             {

--- a/volunteer/tests/test_volunteer_common.py
+++ b/volunteer/tests/test_volunteer_common.py
@@ -11,6 +11,9 @@ class TestVolunteerCommon(common.TransactionCase):
     def setUp(self, *args, **kwargs):
         super().setUp(*args, **kwargs)
 
+        # Force all operations to run as admin
+        self.env = self.env(user=self.env.ref("base.user_admin"))
+
         # Set up the environment
         self.env = self.env(
             context=dict(

--- a/volunteer/tests/test_volunteer_common.py
+++ b/volunteer/tests/test_volunteer_common.py
@@ -29,6 +29,7 @@ class TestVolunteerCommon(common.TransactionCase):
         self.Volunteer = self.env["volunteer.volunteer"]
         self.Participation = self.env["volunteer.shift.participation"]
         self.Generator = self.env["volunteer.shift.recurrent.generator"]
+        self.Subscription = self.env["volunteer.shift.recurrent.subscription"]
 
         # Stages
         self.stage_confirmed = self.env.ref("volunteer.volunteer_shift_stage_confirmed")

--- a/volunteer/tests/test_volunteer_generator_subscription_common.py
+++ b/volunteer/tests/test_volunteer_generator_subscription_common.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from datetime import date, datetime
+
+from .test_volunteer_common import TestVolunteerCommon
+
+
+class TestVolunteerGeneratorSubscriptionCommon(TestVolunteerCommon):
+    def setUp(self, *args, **kwargs):
+        super().setUp(*args, **kwargs)
+
+        # Fix number of occurrences for all tests
+        self.env.company.shift_nb_occurrence = 10
+
+        # Create recurrent generators
+        self.gen_with_past_start = self.Generator.create(
+            {
+                "name": "GenPastStart",
+                "state": "draft",
+                "until_date": date(2025, 12, 31),
+                "interval_type": "days",
+                "interval": 1,
+                "start_time": datetime(2024, 1, 1, 10, 5),
+                "end_time": datetime(2024, 1, 1, 12, 5),
+                "tz": "Europe/Brussels",
+                "max_volunteer_nb": 6,
+                "type_id": self.type1.id,
+            }
+        )
+        self.gen_today_to_infinite_empty = self.Generator.create(
+            {
+                "name": "GenFromTodayToInfiniteWithoutSubscription",
+                "state": "draft",
+                "interval_type": "days",
+                "interval": 1,
+                "start_time": datetime(2025, 1, 1, 10, 5),
+                "end_time": datetime(2025, 1, 1, 12, 5),
+                "tz": "Europe/Brussels",
+                "max_volunteer_nb": 6,
+                "type_id": self.type1.id,
+            }
+        )

--- a/volunteer/tests/test_volunteer_recurrent_subscription_participation.py
+++ b/volunteer/tests/test_volunteer_recurrent_subscription_participation.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: 2025 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from datetime import date, datetime
+
+from freezegun import freeze_time
+
+from .test_volunteer_generator_subscription_common import (
+    TestVolunteerGeneratorSubscriptionCommon,
+)
+
+
+@freeze_time("2025-01-01 10:00:00")
+class TestVolunteerShiftRecurrentSubscriptionParticipation(
+    TestVolunteerGeneratorSubscriptionCommon
+):
+    def setUp(self):
+        super().setUp()
+
+    def test_generate_participation_for_subscription_with_end_date(self):
+        """Test that participation are generated only up to the end_date of the subscription
+        even if the generator has shift generated beyond the subscription end_date.
+        """
+        # Generator start_date is 2025/01/01,
+        # last shift generated is 2025/01/10 (10 occurrences)
+        self.gen_today_to_infinite_empty.write(
+            {
+                "state": "confirmed",
+            }
+        )
+        self.Subscription.create(
+            {
+                "start_date": date(2025, 1, 6),
+                "end_date": date(2025, 1, 8),
+                "volunteer_id": self.volunteer_test.id,
+                "generator_id": self.gen_today_to_infinite_empty.id,
+            }
+        )
+        # Search shifts from 2025-01-06 to 2025-01-08 (3 shifts)
+        # which is within subscription dates
+        shifts = self.Shift.search(
+            [
+                ("start_time", ">=", datetime(2025, 1, 6)),
+                ("start_time", "<", datetime(2025, 1, 9)),
+                ("generator_id", "=", self.gen_today_to_infinite_empty.id),
+            ]
+        )
+        self.assertEqual(len(shifts), 3)
+        parts = self.Participation.search(
+            [
+                ("shift_id", "in", shifts.ids),
+                ("volunteer_id", "=", self.volunteer_test.id),
+                ("registration_state", "=", "confirmed"),
+            ]
+        )
+        self.assertEqual(len(parts), 3)
+        shifts_beyond = self.Shift.search(
+            [
+                ("start_time", ">=", datetime(2025, 1, 9)),
+                ("generator_id", "=", self.gen_today_to_infinite_empty.id),
+            ]
+        )
+        self.assertEqual(len(shifts_beyond), 2)
+        parts_beyond = self.Participation.search(
+            [
+                ("shift_id", "in", shifts_beyond.ids),
+                ("volunteer_id", "=", self.volunteer_test.id),
+                ("registration_state", "=", "confirmed"),
+            ]
+        )
+        self.assertEqual(len(parts_beyond), 0)
+
+    def test_generate_participation_for_subscription_without_end_date(self):
+        """Test that participation are generated for all shifts generated
+        when the subscription has no end_date.
+        """
+        self.gen_today_to_infinite_empty.write(
+            {
+                "state": "confirmed",
+            }
+        )
+        sub_no_end = self.Subscription.create(
+            {
+                "start_date": date(2025, 1, 6),
+                "end_date": False,
+                "volunteer_id": self.volunteer_test.id,
+                "generator_id": self.gen_today_to_infinite_empty.id,
+            }
+        )
+        # Generator start_date is 2025/01/01,
+        # last shift generated is 2025/01/10 (10 occurrences)
+        shifts = self.Shift.search(
+            [
+                ("start_time", ">=", sub_no_end.start_date),
+                ("start_time", "<", date(2025, 1, 11)),
+                ("generator_id", "=", self.gen_today_to_infinite_empty.id),
+            ]
+        )
+        # From start subscription : 2025-01-06
+        # to last date shift generated :2025-01-10
+        # there is 5 shifts generated
+        self.assertEqual(len(shifts), 5)
+        all_participation = self.Participation.search(
+            [
+                ("shift_id", "in", shifts.ids),
+                ("volunteer_id", "=", self.volunteer_test.id),
+                ("registration_state", "=", "confirmed"),
+            ]
+        )
+        self.assertEqual(len(all_participation), 5)
+
+    def test_autocancel_participation_covered_by_new_subscription_same_volunteer(self):
+        """Test that a participation is auto-canceled when a new subscription
+        is created that covers the date of the participation for the same volunteer.
+        """
+        self.gen_today_to_infinite_empty.write(
+            {
+                "state": "confirmed",
+            }
+        )
+        shift = self.Shift.search(
+            [
+                ("start_time", "=", datetime(2025, 1, 7, 10, 5)),
+                ("generator_id", "=", self.gen_today_to_infinite_empty.id),
+            ]
+        )
+        part1 = self.Participation.create(
+            {
+                "shift_id": shift.id,
+                "volunteer_id": self.volunteer_test.id,
+                "registration_state": "confirmed",
+            }
+        )
+        self.assertEqual(
+            part1.registration_state,
+            "confirmed",
+        )
+        # Create a subscription covering 2025-01-07 for the same volunteer
+        self.Subscription.create(
+            {
+                "start_date": date(2025, 1, 6),
+                "end_date": date(2025, 1, 8),
+                "volunteer_id": self.volunteer_test.id,
+                "generator_id": self.gen_today_to_infinite_empty.id,
+            }
+        )
+        # Check that punctual participation is auto-canceled
+        # and recurrent participation is created,
+        # because volunteer is now subscribed for this shift
+        self.assertEqual(
+            part1.registration_state,
+            "canceled",
+        )
+        recurrent_part = self.Participation.search(
+            [
+                ("shift_id", "=", shift.id),
+                ("volunteer_id", "=", self.volunteer_test.id),
+                ("registration_type", "=", "recurrent"),
+                ("registration_state", "=", "confirmed"),
+            ]
+        )
+        self.assertEqual(len(recurrent_part), 1)

--- a/volunteer/tests/test_volunteer_shift_recurrent_generator_cancellation.py
+++ b/volunteer/tests/test_volunteer_shift_recurrent_generator_cancellation.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2025 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from datetime import date
+
+from freezegun import freeze_time
+
+from .test_volunteer_generator_subscription_common import (
+    TestVolunteerGeneratorSubscriptionCommon,
+)
+
+
+@freeze_time("2025-01-01 10:00:00")
+class TestVolunteerShiftRecurrentGeneratorCancellation(
+    TestVolunteerGeneratorSubscriptionCommon
+):
+    def setUp(self):
+        super().setUp()
+
+    def test_generator_cancellation_automation(self):
+        """Test that canceling a generator cancels future shifts
+        and set subscriptions end_date and until_date generator to today.
+        """
+        self.gen_with_past_start.write({"state": "confirmed"})
+        past_sub = self.Subscription.create(
+            {
+                "start_date": date(2024, 12, 1),
+                "end_date": date(2024, 12, 5),
+                "volunteer_id": self.volunteer_canceled.id,
+                "generator_id": self.gen_with_past_start.id,
+            }
+        )
+        active_sub = self.Subscription.create(
+            {
+                "start_date": date(2024, 1, 1),
+                "end_date": date(2025, 1, 10),
+                "volunteer_id": self.volunteer_confirmed.id,
+                "generator_id": self.gen_with_past_start.id,
+            }
+        )
+        future_sub = self.Subscription.create(
+            {
+                "start_date": date(2025, 1, 5),
+                "end_date": date(2025, 1, 10),
+                "volunteer_id": self.volunteer_test.id,
+                "generator_id": self.gen_with_past_start.id,
+            }
+        )
+        self.gen_with_past_start.write({"state": "canceled"})
+        today = date.today()
+        future_shifts = self.gen_with_past_start.volunteer_shift_ids.filtered(
+            lambda s: s.start_time.date() >= today
+        )
+        self.assertGreater(len(future_shifts), 0)
+        for shift in future_shifts:
+            self.assertEqual(shift.stage_id, self.stage_canceled)
+        self.assertEqual(active_sub.end_date, today)
+        self.assertEqual(future_sub.end_date, today)
+        self.assertEqual(past_sub.end_date, date(2024, 12, 5))
+        self.assertEqual(self.gen_with_past_start.until_date, today)

--- a/volunteer/tests/test_volunteer_shift_recurrent_generator_cancellation.py
+++ b/volunteer/tests/test_volunteer_shift_recurrent_generator_cancellation.py
@@ -2,9 +2,11 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-from datetime import date
+from datetime import date, datetime
 
 from freezegun import freeze_time
+
+from odoo.exceptions import UserError
 
 from .test_volunteer_generator_subscription_common import (
     TestVolunteerGeneratorSubscriptionCommon,
@@ -17,6 +19,24 @@ class TestVolunteerShiftRecurrentGeneratorCancellation(
 ):
     def setUp(self):
         super().setUp()
+
+    def test_cannot_create_generator_in_canceled_state(self):
+        """Test that creating a generator directly in canceled state is prohibited"""
+        with self.assertRaises(UserError):
+            self.Generator.create(
+                {
+                    "name": "GenCanceled",
+                    "state": "canceled",
+                    "until_date": date(2025, 12, 31),
+                    "interval_type": "days",
+                    "interval": 1,
+                    "start_time": datetime(2024, 1, 1, 10, 5),
+                    "end_time": datetime(2024, 1, 1, 12, 5),
+                    "tz": "Europe/Brussels",
+                    "max_volunteer_nb": 6,
+                    "type_id": self.type1.id,
+                }
+            )
 
     def test_generator_cancellation_automation(self):
         """Test that canceling a generator cancels future shifts

--- a/volunteer/tests/test_volunteer_shift_recurrent_generator_generation.py
+++ b/volunteer/tests/test_volunteer_shift_recurrent_generator_generation.py
@@ -170,6 +170,7 @@ class TestVolunteerShiftRecurrentGeneratorGeneration(
                 shifts = self.Shift.search(
                     [("generator_id", "=", generator.id)], order="start_time"
                 )
+                self.assertGreaterEqual(len(shifts), len(expected_start))
                 # Verify interval progression on first 3 shifts
                 for i, expected_date in enumerate(expected_start):
                     self.assertEqual(shifts[i].start_time, expected_date)

--- a/volunteer/tests/test_volunteer_shift_recurrent_generator_generation.py
+++ b/volunteer/tests/test_volunteer_shift_recurrent_generator_generation.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: 2025 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from datetime import date, datetime
+
+from freezegun import freeze_time
+
+from .test_volunteer_generator_subscription_common import (
+    TestVolunteerGeneratorSubscriptionCommon,
+)
+
+
+@freeze_time("2025-01-01 10:00:00")
+class TestVolunteerShiftRecurrentGeneratorGeneration(
+    TestVolunteerGeneratorSubscriptionCommon
+):
+    def setUp(self):
+        super().setUp()
+
+    def test_generate_shifts_with_past_start_date(self):
+        """Test that shifts are generated from today
+        when generator start_date is in the past
+        """
+        # Generator starts in the past (2024-01-01), today freeze to 2025-01-01,
+        # shifts should be generated starting from today only
+        self.gen_with_past_start.write({"state": "confirmed"})
+        shifts = self.Shift.search([("generator_id", "=", self.gen_with_past_start.id)])
+        self.assertEqual(shifts[0].start_time.date(), date.today())
+
+    def test_generate_shifts_from_start_date_future(self):
+        """Test that shifts are generated from the configured start_date
+        when it's in the future
+        """
+        # Today is frozen to 2025-01-01
+        self.gen_today_to_infinite_empty.write(
+            {
+                "start_time": datetime(2025, 2, 1, 10, 5),
+                "end_time": datetime(2025, 2, 1, 12, 5),
+            }
+        )
+        self.gen_today_to_infinite_empty.write({"state": "confirmed"})
+        shifts = self.Shift.search(
+            [("generator_id", "=", self.gen_today_to_infinite_empty.id)]
+        )
+        start_date = self.gen_today_to_infinite_empty.start_time.date()
+        self.assertEqual(shifts[0].start_time.date(), start_date)
+
+    def test_generate_right_number_of_shifts_generator_with_until_date(self):
+        """Test that the right number of shifts are generated
+        based on until_date and not on number of occurrences
+        """
+        # Between 2025-01-01 and 2025-01-05 there are 5 occurrences
+        # and not 10 like number of occurrences
+        self.gen_today_to_infinite_empty.write(
+            {
+                "start_time": datetime(2025, 1, 1, 10, 5),
+                "end_time": datetime(2025, 1, 1, 12, 5),
+                "until_date": date(2025, 1, 5),
+            }
+        )
+        self.gen_today_to_infinite_empty.write({"state": "confirmed"})
+        shifts = self.Shift.search(
+            [("generator_id", "=", self.gen_today_to_infinite_empty.id)]
+        )
+        self.assertEqual(len(shifts), 5)
+
+    def test_generate_right_number_of_shifts_generator_without_until_date(self):
+        """Test that the right number of shifts are generated
+        based on number of occurrences since there is no until_date
+        """
+        # Number of occurrences is 10
+        # Today is frozen to 2025-01-01, so shifts will be generated from this date
+        self.gen_today_to_infinite_empty.write(
+            {
+                "start_time": datetime(2025, 1, 1, 10, 5),
+                "end_time": datetime(2025, 1, 1, 12, 5),
+            }
+        )
+        self.gen_today_to_infinite_empty.write({"state": "confirmed"})
+        shifts = self.Shift.search(
+            [("generator_id", "=", self.gen_today_to_infinite_empty.id)]
+        )
+        self.assertEqual(len(shifts), 10)
+
+    def test_generate_shifts_with_right_period(self):
+        """Test that the shifts are generated with the right start and end time"""
+        self.gen_today_to_infinite_empty.write(
+            {
+                "start_time": datetime(2025, 1, 1, 10, 5),
+                "end_time": datetime(2025, 1, 1, 12, 5),
+                "until_date": date(2025, 1, 6),
+            }
+        )
+        self.gen_today_to_infinite_empty.write({"state": "confirmed"})
+        shifts = self.Shift.search(
+            [("generator_id", "=", self.gen_today_to_infinite_empty.id)]
+        )
+        expected_start = datetime(2025, 1, 1, 10, 5)
+        expected_end = datetime(2025, 1, 1, 12, 5)
+        # Each generated shift must strictly match the configured time slot
+        # with the correct interval applied between occurrences
+        for shift in shifts:
+            self.assertEqual(shift.start_time, expected_start)
+            self.assertEqual(shift.end_time, expected_end)
+            expected_start = (
+                expected_start + self.gen_today_to_infinite_empty._get_interval_delta()
+            )
+            expected_end = (
+                expected_end + self.gen_today_to_infinite_empty._get_interval_delta()
+            )
+
+    def test_generate_shifts_different_intervals(self):
+        """Test shift generation with different interval types"""
+        intervals = [
+            (
+                "days",
+                3,
+                [
+                    datetime(2025, 1, 1, 10, 0),
+                    datetime(2025, 1, 4, 10, 0),
+                    datetime(2025, 1, 7, 10, 0),
+                ],
+            ),
+            (
+                "weeks",
+                2,
+                [
+                    datetime(2025, 1, 1, 10, 0),
+                    datetime(2025, 1, 15, 10, 0),
+                    datetime(2025, 1, 29, 10, 0),
+                ],
+            ),
+            (
+                "months",
+                3,
+                [
+                    datetime(2025, 1, 1, 10, 0),
+                    datetime(2025, 4, 1, 10, 0),
+                    datetime(2025, 7, 1, 10, 0),
+                ],
+            ),
+            (
+                "years",
+                1,
+                [
+                    datetime(2025, 1, 1, 10, 0),
+                    datetime(2026, 1, 1, 10, 0),
+                    datetime(2027, 1, 1, 10, 0),
+                ],
+            ),
+        ]
+        for interval_type, interval_value, expected_start in intervals:
+            with self.subTest(interval_type=interval_type, interval=interval_value):
+                # Create new generator for each test
+                generator = self.Generator.create(
+                    {
+                        "name": f"Test each {interval_value} {interval_type}",
+                        "state": "draft",
+                        "interval_type": interval_type,
+                        "interval": interval_value,
+                        "start_time": datetime(2025, 1, 1, 10, 0),
+                        "end_time": datetime(2025, 1, 1, 12, 0),
+                        "max_volunteer_nb": 3,
+                        "type_id": self.type1.id,
+                        "tz": "Europe/Brussels",
+                    }
+                )
+                generator.write({"state": "confirmed"})
+                shifts = self.Shift.search(
+                    [("generator_id", "=", generator.id)], order="start_time"
+                )
+                # Verify interval progression on first 3 shifts
+                for i, expected_date in enumerate(expected_start):
+                    self.assertEqual(shifts[i].start_time, expected_date)

--- a/volunteer/tests/test_volunteer_shift_recurrent_subscription_participation.py
+++ b/volunteer/tests/test_volunteer_shift_recurrent_subscription_participation.py
@@ -161,3 +161,128 @@ class TestVolunteerShiftRecurrentSubscriptionParticipation(
             ]
         )
         self.assertEqual(len(recurrent_part), 1)
+
+    def test_autocancel_participation_covered_by_modified_sub_same_volunteer(self):
+        """Test that a participation is auto-canceled when an existing subscription
+        is modified to cover the date of the participation for the same volunteer."""
+        self.gen_today_to_infinite_empty.with_user(self.user_admin).write(
+            {
+                "state": "confirmed",
+            }
+        )
+        shift = self.Shift.search(
+            [
+                ("start_time", "=", datetime(2025, 1, 8, 10, 5)),
+                ("generator_id", "=", self.gen_today_to_infinite_empty.id),
+            ]
+        )
+        part = self.Participation.create(
+            {
+                "shift_id": shift.id,
+                "volunteer_id": self.volunteer_test.id,
+                "registration_state": "confirmed",
+            }
+        )
+        self.assertEqual(
+            part.registration_state,
+            "confirmed",
+        )
+        sub = self.Subscription.create(
+            {
+                "start_date": date(2025, 1, 4),
+                "end_date": date(2025, 1, 6),
+                "volunteer_id": self.volunteer_test.id,
+                "generator_id": self.gen_today_to_infinite_empty.id,
+            }
+        )
+        # Extend subscription to infinite to cover participation date
+        sub.write(
+            {
+                "end_date": False,
+            }
+        )
+        self.assertEqual(
+            part.registration_state,
+            "canceled",
+        )
+        recurrent_part = self.Participation.search(
+            [
+                ("shift_id", "=", shift.id),
+                ("volunteer_id", "=", self.volunteer_test.id),
+                ("registration_type", "=", "recurrent"),
+                ("registration_state", "=", "confirmed"),
+            ]
+        )
+        self.assertEqual(len(recurrent_part), 1)
+
+    def test_managing_cancel_or_create_participation(self):
+        """Test managing canceling or creating participation when modifying
+        a subscription end_date including setting it to None (no end)."""
+        self.gen_today_to_infinite_empty.with_user(self.user_admin).write(
+            {"state": "confirmed"}
+        )
+        sub = self.Subscription.create(
+            {
+                "start_date": date(2025, 1, 7),
+                "end_date": date(2025, 1, 10),
+                "volunteer_id": self.volunteer_test.id,
+                "generator_id": self.gen_today_to_infinite_empty.id,
+            }
+        )
+        shift_8 = self.Shift.search(
+            [
+                ("start_time", "=", datetime(2025, 1, 8, 10, 5)),
+                ("generator_id", "=", self.gen_today_to_infinite_empty.id),
+            ]
+        )
+        part_8_confirmed = self.Participation.search(
+            [
+                ("shift_id", "=", shift_8.id),
+                ("volunteer_id", "=", self.volunteer_test.id),
+                ("registration_type", "=", "recurrent"),
+                ("registration_state", "=", "confirmed"),
+            ]
+        )
+        self.assertEqual(len(part_8_confirmed), 1)
+        # Reduce end date to 2025-01-07
+        # needs to cancel participation on 2025-01-08
+        sub.write({"end_date": date(2025, 1, 7)})
+        part_8_canceled = self.Participation.search(
+            [
+                ("shift_id", "=", shift_8.id),
+                ("volunteer_id", "=", self.volunteer_test.id),
+                ("registration_type", "=", "recurrent"),
+                ("registration_state", "=", "canceled"),
+            ]
+        )
+        # Check that participation for shift on 2025-01-08 is canceled
+        # and there is no other confirmed participation for this shift
+        # and volunteer
+        self.assertEqual(len(part_8_canceled), 1)
+        part_8 = self.Participation.search(
+            [
+                ("shift_id", "=", shift_8.id),
+                ("volunteer_id", "=", self.volunteer_test.id),
+                ("registration_type", "=", "recurrent"),
+                ("registration_state", "=", "confirmed"),
+            ]
+        )
+        self.assertEqual(len(part_8), 0)
+        # Modify end date to False (infinite)
+        # needs to create participation after 2025-01-08 (check 2025-01-10)
+        sub.write({"end_date": False})
+        shift_10 = self.Shift.search(
+            [
+                ("start_time", "=", datetime(2025, 1, 10, 10, 5)),
+                ("generator_id", "=", self.gen_today_to_infinite_empty.id),
+            ]
+        )
+        part_10 = self.Participation.search(
+            [
+                ("shift_id", "=", shift_10.id),
+                ("volunteer_id", "=", self.volunteer_test.id),
+                ("registration_type", "=", "recurrent"),
+                ("registration_state", "=", "confirmed"),
+            ]
+        )
+        self.assertEqual(len(part_10), 1)


### PR DESCRIPTION
## Description

This PR adds automations for generators and subscriptions:
- Add shifts generation when generator is confirmed
- Add participation generation for new subscriptions
- Add subscriptions modification management, with cancellation and generation of participation if needed
- Manage cancellation of punctual participation if covered by a subscription (new or modified)
- Prevent generator creation in canceled state
- Add generator cancellation automation
- Add related tests and dedicated common setup for generators and subscriptions


## Checklist before approval

- [X] Tests are present (or not needed).
- [X] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [X] (If a new module) Moving this to OCA has been considered.
