### PR TITLE
[16.0][FIX] volunteer: handle multi-day shifts in subscription management

### DIFF
--- a/volunteer/models/volunteer_shift_recurrent_generator.py
+++ b/volunteer/models/volunteer_shift_recurrent_generator.py
@@ -135,22 +135,29 @@ class VolunteerShiftRecurrentGenerator(models.Model):
         self.ensure_one()
         today = fields.Date.today()
         future_subscriptions = self.volunteer_subscription_ids.filtered(
-            lambda subscription: subscription.start_date >= today
+            lambda subscription: subscription.start_date > today
         )
         return future_subscriptions
 
     def _get_future_shifts(self):
         """Get all future shifts for this generator."""
         self.ensure_one()
-        today = fields.Date.today()
-        return self.volunteer_shift_ids.filtered(
-            lambda shift: shift.start_time.date() >= today
+        tomorrow = fields.Date.today() + timedelta(days=1)
+        return self.env["volunteer.shift"].search(
+            [
+                ("generator_id", "=", self.id),
+                ("start_time", ">=", tomorrow),
+            ]
         )
 
     def _generate_shifts(self):
         """Generate all shifts from the generator start date
         until the generator until date or number of occurrences,
         using the specified interval.
+
+        When the generator start date is in the past or equal to today,
+        shift generation starts strictly from tomorrow (day-based logic).
+        No shift is generated for the current day, regardless of the confirmation time.
         """
         self.ensure_one()
         nb_occurrence = self.company_id.shift_nb_occurrence
@@ -171,7 +178,7 @@ class VolunteerShiftRecurrentGenerator(models.Model):
         shift_to_generate_start_time = self.start_time
         shift_to_generate_end_time = self.end_time
         # Skip past occurrences by incrementing with delta until reaching a future date
-        while shift_to_generate_start_time.date() < today:
+        while shift_to_generate_start_time.date() <= today:
             shift_to_generate_start_time += delta
             shift_to_generate_end_time += delta
         nb_shift_to_generate = 0

--- a/volunteer/models/volunteer_shift_recurrent_generator.py
+++ b/volunteer/models/volunteer_shift_recurrent_generator.py
@@ -168,36 +168,28 @@ class VolunteerShiftRecurrentGenerator(models.Model):
             generation_end_date = generation_start_date
             for _i in range(nb_occurrence):
                 generation_end_date += delta
-        shift_generated_start_time = self.start_time
-        shift_generated_end_time = self.end_time
+        shift_to_generate_start_time = self.start_time
+        shift_to_generate_end_time = self.end_time
         # Skip past occurrences by incrementing with delta until reaching a future date
-        while shift_generated_start_time.date() < today:
-            shift_generated_start_time += delta
-            shift_generated_end_time += delta
-        nb_generated_shift = 0
+        while shift_to_generate_start_time.date() < today:
+            shift_to_generate_start_time += delta
+            shift_to_generate_end_time += delta
+        nb_shift_to_generate = 0
+        shifts_to_create = []
         while (
-            nb_generated_shift < nb_occurrence
-            and shift_generated_start_time.date() <= generation_end_date
+            nb_shift_to_generate < nb_occurrence
+            and shift_to_generate_start_time.date() <= generation_end_date
         ):
-            self.env["volunteer.shift"].create(
-                {
-                    "name": self.name,
-                    "tz": self.tz,
-                    "start_time": shift_generated_start_time,
-                    "end_time": shift_generated_end_time,
-                    "max_volunteer_nb": self.max_volunteer_nb,
-                    "stage_id": stage_confirmed.id,
-                    "type_id": self.type_id.id,
-                    "category_id": self.category_id.id,
-                    "tag_ids": self.tag_ids.ids,
-                    "generator_id": self.id,
-                    "company_id": self.company_id.id,
-                    "coordinator_id": self.coordinator_id.id,
-                }
+            vals = self._prepare_shift_vals(
+                shift_to_generate_start_time,
+                shift_to_generate_end_time,
+                stage_confirmed,
             )
-            shift_generated_start_time += delta
-            shift_generated_end_time += delta
-            nb_generated_shift += 1
+            shifts_to_create.append(vals)
+            shift_to_generate_start_time += delta
+            shift_to_generate_end_time += delta
+            nb_shift_to_generate += 1
+        return self.env["volunteer.shift"].create(shifts_to_create)
 
     def _generate_all_participation(self):
         """Generate participation for all subscriptions in the generator"""
@@ -226,3 +218,24 @@ class VolunteerShiftRecurrentGenerator(models.Model):
         # and need to be bypassed)
         res = super(VolunteerShiftRecurrentGenerator, self).write({"until_date": today})
         return res
+
+    def _prepare_shift_vals(self, shift_start_time, shift_end_time, shift_stage):
+        """Prepare vals to create a shift in the given stage
+        with specified start and end time for this generator.
+        """
+        self.ensure_one()
+        shift_vals = {
+            "name": self.name,
+            "tz": self.tz,
+            "start_time": shift_start_time,
+            "end_time": shift_end_time,
+            "max_volunteer_nb": self.max_volunteer_nb,
+            "stage_id": shift_stage.id,
+            "type_id": self.type_id.id,
+            "category_id": self.category_id.id,
+            "tag_ids": self.tag_ids.ids,
+            "generator_id": self.id,
+            "company_id": self.company_id.id,
+            "coordinator_id": self.coordinator_id.id,
+        }
+        return shift_vals

--- a/volunteer/models/volunteer_shift_recurrent_subscription.py
+++ b/volunteer/models/volunteer_shift_recurrent_subscription.py
@@ -122,14 +122,9 @@ class VolunteerShiftRecurrentSubscription(models.Model):
         participation_to_create = []
         for shift in shifts:
             participation_to_create.append(
-                {
-                    "shift_id": shift.id,
-                    "volunteer_id": self.volunteer_id.id,
-                    "registration_type": "recurrent",
-                    "registration_state": "confirmed",
-                }
+                self._prepare_participation_vals(shift.id, "recurrent", "confirmed")
             )
-        self.env["volunteer.shift.participation"].create(participation_to_create)
+        return self.env["volunteer.shift.participation"].create(participation_to_create)
 
     def _cancel_participation_by_shifts(self, shifts):
         """Cancel all participation for given shifts
@@ -235,3 +230,18 @@ class VolunteerShiftRecurrentSubscription(models.Model):
             )
             # Cancel participation for shifts no longer covered by the subscription
             self._cancel_participation_by_shifts(shifts_old_sub_only)
+
+    def _prepare_participation_vals(
+        self, shift_id, registration_type, registration_state
+    ):
+        """Prepare vals to create a participation with given registration type and state
+        for this subscription's volunteer and the given shift.
+        """
+        self.ensure_one()
+        participation_vals = {
+            "shift_id": shift_id,
+            "volunteer_id": self.volunteer_id.id,
+            "registration_type": registration_type,
+            "registration_state": registration_state,
+        }
+        return participation_vals

--- a/volunteer/models/volunteer_shift_recurrent_subscription.py
+++ b/volunteer/models/volunteer_shift_recurrent_subscription.py
@@ -84,8 +84,9 @@ class VolunteerShiftRecurrentSubscription(models.Model):
             # No intersection
             return []
         shifts_intersection = self.generator_id.volunteer_shift_ids.filtered(
-            lambda shift: shift.start_time.date() >= intersection_start_date
-            and shift.end_time.date() <= intersection_end_date
+            lambda shift: intersection_start_date
+            <= shift.start_time.date()
+            <= intersection_end_date
         )
         return shifts_intersection
 
@@ -107,7 +108,7 @@ class VolunteerShiftRecurrentSubscription(models.Model):
         )
         if self.end_date:
             shifts = shifts.filtered(
-                lambda shift: shift.end_time.date() <= self.end_date
+                lambda shift: shift.start_time.date() <= self.end_date
             )
         return shifts
 
@@ -185,9 +186,9 @@ class VolunteerShiftRecurrentSubscription(models.Model):
             return
         new_end_date = self.end_date
         new_start_date = self.start_date
-        date_last_shift = future_shifts.sorted("end_time", reverse=True)[
+        date_last_shift = future_shifts.sorted("start_time", reverse=True)[
             0
-        ].end_time.date()
+        ].start_time.date()
         if not new_end_date:
             new_end_date = date_last_shift
         if not old_end_date:
@@ -198,8 +199,7 @@ class VolunteerShiftRecurrentSubscription(models.Model):
         if not shifts_intersection:
             # No intersection : all old shifts need to be canceled
             old_shifts = future_shifts.filtered(
-                lambda shift: shift.start_time.date() >= old_start_date
-                and shift.end_time.date() <= old_end_date
+                lambda shift: old_start_date <= shift.start_time.date() <= old_end_date
             )
             self._cancel_participation_by_shifts(old_shifts)
             # All shifts covered by the new subscription need to be generated
@@ -212,21 +212,20 @@ class VolunteerShiftRecurrentSubscription(models.Model):
             end_date_full_period = max(new_end_date, old_end_date)
             # Filter the full period excluding the intersection period
             shifts_full_period_without_intersection = future_shifts.filtered(
-                lambda shift: shift.start_time.date() >= start_date_full_period
-                and shift.end_time.date() <= end_date_full_period
+                lambda shift: start_date_full_period
+                <= shift.start_time.date()
+                <= end_date_full_period
                 and shift.id not in shifts_intersection.ids
             )
             # Filter the period of new subscription without intersection and in the full range
             shifts_new_sub_only = shifts_full_period_without_intersection.filtered(
-                lambda shift: shift.start_time.date() >= new_start_date
-                and shift.end_time.date() <= new_end_date
+                lambda shift: new_start_date <= shift.start_time.date() <= new_end_date
             )
             # Generate participation for shifts newly covered by the subscription
             self._generate_participation_by_shifts(shifts_new_sub_only)
             # Filter the period of old subscription without intersection and in the full range
             shifts_old_sub_only = shifts_full_period_without_intersection.filtered(
-                lambda shift: shift.start_time.date() >= old_start_date
-                and shift.end_time.date() <= old_end_date
+                lambda shift: old_start_date <= shift.start_time.date() <= old_end_date
             )
             # Cancel participation for shifts no longer covered by the subscription
             self._cancel_participation_by_shifts(shifts_old_sub_only)

--- a/volunteer/tests/test_volunteer_generator_subscription_common.py
+++ b/volunteer/tests/test_volunteer_generator_subscription_common.py
@@ -42,3 +42,15 @@ class TestVolunteerGeneratorSubscriptionCommon(TestVolunteerCommon):
                 "type_id": self.type1.id,
             }
         )
+        self.gen_shift_2_days = self.Generator.create(
+            {
+                "name": "Generator with 2 days shift",
+                "state": "draft",
+                "interval_type": "days",
+                "interval": 1,
+                "start_time": datetime(2025, 1, 1, 10, 5),
+                "end_time": datetime(2025, 1, 2, 12, 5),
+                "max_volunteer_nb": 2,
+                "type_id": self.type1.id,
+            }
+        )

--- a/volunteer/tests/test_volunteer_shift_recurrent_generator_cancellation.py
+++ b/volunteer/tests/test_volunteer_shift_recurrent_generator_cancellation.py
@@ -40,7 +40,10 @@ class TestVolunteerShiftRecurrentGeneratorCancellation(
 
     def test_generator_cancellation_automation(self):
         """Test that canceling a generator cancels future shifts
-        and set subscriptions end_date and until_date generator to today.
+        and sets subscriptions end_date and until_date generator to today.
+
+        Cancellation strictly applied to future shifts, excluding today,
+        independently of time (starting from tomorrow).
         """
         self.gen_with_past_start.write({"state": "confirmed"})
         past_sub = self.Subscription.create(
@@ -70,7 +73,7 @@ class TestVolunteerShiftRecurrentGeneratorCancellation(
         self.gen_with_past_start.write({"state": "canceled"})
         today = date.today()
         future_shifts = self.gen_with_past_start.volunteer_shift_ids.filtered(
-            lambda s: s.start_time.date() >= today
+            lambda s: s.start_time.date() > today
         )
         self.assertGreater(len(future_shifts), 0)
         for shift in future_shifts:
@@ -79,3 +82,18 @@ class TestVolunteerShiftRecurrentGeneratorCancellation(
         self.assertEqual(future_sub.end_date, today)
         self.assertEqual(past_sub.end_date, date(2024, 12, 5))
         self.assertEqual(self.gen_with_past_start.until_date, today)
+
+    def test_generator_cancellation_excludes_today_shifts(self):
+        """Test that canceling a generator only cancels shifts starting from tomorrow.
+        If there is a shift today, it must remain confirmed.
+        """
+        self.gen_with_past_start.write({"state": "confirmed"})
+        # Advance time to a later date to ensure there is an actual shift generated today.
+        with freeze_time("2025-01-04"):
+            self.gen_with_past_start.write({"state": "canceled"})
+            today = date.today()
+            today_shift = self.gen_with_past_start.volunteer_shift_ids.filtered(
+                lambda s: s.start_time.date() == today
+            )
+            self.assertEqual(len(today_shift), 1)
+            self.assertEqual(today_shift[0].stage_id, self.stage_confirmed)

--- a/volunteer/tests/test_volunteer_shift_recurrent_generator_generation.py
+++ b/volunteer/tests/test_volunteer_shift_recurrent_generator_generation.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 from freezegun import freeze_time
 
@@ -19,14 +19,18 @@ class TestVolunteerShiftRecurrentGeneratorGeneration(
         super().setUp()
 
     def test_generate_shifts_with_past_start_date(self):
-        """Test that shifts are generated from today
+        """Test that shifts are generated from tomorrow
         when generator start_date is in the past
         """
         # Generator starts in the past (2024-01-01), today freeze to 2025-01-01,
-        # shifts should be generated starting from today only
+        # shifts should be generated starting from tomorrow only : 2025-01-02
+        # (generator had interval of one day).
         self.gen_with_past_start.write({"state": "confirmed"})
-        shifts = self.Shift.search([("generator_id", "=", self.gen_with_past_start.id)])
-        self.assertEqual(shifts[0].start_time.date(), date.today())
+        shifts = self.Shift.search(
+            [("generator_id", "=", self.gen_with_past_start.id)], order="start_time"
+        )
+        self.assertTrue(shifts)
+        self.assertEqual(shifts[0].start_time.date(), date.today() + timedelta(days=1))
 
     def test_generate_shifts_from_start_date_future(self):
         """Test that shifts are generated from the configured start_date
@@ -41,8 +45,10 @@ class TestVolunteerShiftRecurrentGeneratorGeneration(
         )
         self.gen_today_to_infinite_empty.write({"state": "confirmed"})
         shifts = self.Shift.search(
-            [("generator_id", "=", self.gen_today_to_infinite_empty.id)]
+            [("generator_id", "=", self.gen_today_to_infinite_empty.id)],
+            order="start_time",
         )
+        self.assertTrue(shifts)
         start_date = self.gen_today_to_infinite_empty.start_time.date()
         self.assertEqual(shifts[0].start_time.date(), start_date)
 
@@ -50,12 +56,12 @@ class TestVolunteerShiftRecurrentGeneratorGeneration(
         """Test that the right number of shifts are generated
         based on until_date and not on number of occurrences
         """
-        # Between 2025-01-01 and 2025-01-05 there are 5 occurrences
+        # Between 2025-01-02 and 2025-01-05 there are 4 occurrences
         # and not 10 like number of occurrences
         self.gen_today_to_infinite_empty.write(
             {
-                "start_time": datetime(2025, 1, 1, 10, 5),
-                "end_time": datetime(2025, 1, 1, 12, 5),
+                "start_time": datetime(2025, 1, 2, 10, 5),
+                "end_time": datetime(2025, 1, 2, 12, 5),
                 "until_date": date(2025, 1, 5),
             }
         )
@@ -63,14 +69,14 @@ class TestVolunteerShiftRecurrentGeneratorGeneration(
         shifts = self.Shift.search(
             [("generator_id", "=", self.gen_today_to_infinite_empty.id)]
         )
-        self.assertEqual(len(shifts), 5)
+        self.assertEqual(len(shifts), 4)
 
     def test_generate_right_number_of_shifts_generator_without_until_date(self):
         """Test that the right number of shifts are generated
         based on number of occurrences since there is no until_date
         """
-        # Number of occurrences is 10
-        # Today is frozen to 2025-01-01, so shifts will be generated from this date
+        # Number of occurrences is 10. Today is frozen to 2025-01-01,
+        # so shifts will be generated from 2025-01-02
         self.gen_today_to_infinite_empty.write(
             {
                 "start_time": datetime(2025, 1, 1, 10, 5),
@@ -87,8 +93,8 @@ class TestVolunteerShiftRecurrentGeneratorGeneration(
         """Test that the shifts are generated with the right start and end time"""
         self.gen_today_to_infinite_empty.write(
             {
-                "start_time": datetime(2025, 1, 1, 10, 5),
-                "end_time": datetime(2025, 1, 1, 12, 5),
+                "start_time": datetime(2025, 1, 2, 10, 5),
+                "end_time": datetime(2025, 1, 2, 12, 5),
                 "until_date": date(2025, 1, 6),
             }
         )
@@ -96,8 +102,8 @@ class TestVolunteerShiftRecurrentGeneratorGeneration(
         shifts = self.Shift.search(
             [("generator_id", "=", self.gen_today_to_infinite_empty.id)]
         )
-        expected_start = datetime(2025, 1, 1, 10, 5)
-        expected_end = datetime(2025, 1, 1, 12, 5)
+        expected_start = datetime(2025, 1, 2, 10, 5)
+        expected_end = datetime(2025, 1, 2, 12, 5)
         # Each generated shift must strictly match the configured time slot
         # with the correct interval applied between occurrences
         for shift in shifts:
@@ -111,42 +117,44 @@ class TestVolunteerShiftRecurrentGeneratorGeneration(
             )
 
     def test_generate_shifts_different_intervals(self):
-        """Test shift generation with different interval types"""
+        """Test shift generation with different interval types.
+        The first generated shift starts on tomorrow (2025-01-02).
+        """
         intervals = [
             (
                 "days",
                 3,
                 [
-                    datetime(2025, 1, 1, 10, 0),
-                    datetime(2025, 1, 4, 10, 0),
-                    datetime(2025, 1, 7, 10, 0),
+                    datetime(2025, 1, 2, 10, 0),
+                    datetime(2025, 1, 5, 10, 0),
+                    datetime(2025, 1, 8, 10, 0),
                 ],
             ),
             (
                 "weeks",
                 2,
                 [
-                    datetime(2025, 1, 1, 10, 0),
-                    datetime(2025, 1, 15, 10, 0),
-                    datetime(2025, 1, 29, 10, 0),
+                    datetime(2025, 1, 2, 10, 0),
+                    datetime(2025, 1, 16, 10, 0),
+                    datetime(2025, 1, 30, 10, 0),
                 ],
             ),
             (
                 "months",
                 3,
                 [
-                    datetime(2025, 1, 1, 10, 0),
-                    datetime(2025, 4, 1, 10, 0),
-                    datetime(2025, 7, 1, 10, 0),
+                    datetime(2025, 1, 2, 10, 0),
+                    datetime(2025, 4, 2, 10, 0),
+                    datetime(2025, 7, 2, 10, 0),
                 ],
             ),
             (
                 "years",
                 1,
                 [
-                    datetime(2025, 1, 1, 10, 0),
-                    datetime(2026, 1, 1, 10, 0),
-                    datetime(2027, 1, 1, 10, 0),
+                    datetime(2025, 1, 2, 10, 0),
+                    datetime(2026, 1, 2, 10, 0),
+                    datetime(2027, 1, 2, 10, 0),
                 ],
             ),
         ]
@@ -159,8 +167,8 @@ class TestVolunteerShiftRecurrentGeneratorGeneration(
                         "state": "draft",
                         "interval_type": interval_type,
                         "interval": interval_value,
-                        "start_time": datetime(2025, 1, 1, 10, 0),
-                        "end_time": datetime(2025, 1, 1, 12, 0),
+                        "start_time": datetime(2025, 1, 2, 10, 0),
+                        "end_time": datetime(2025, 1, 2, 12, 0),
                         "max_volunteer_nb": 3,
                         "type_id": self.type1.id,
                         "tz": "Europe/Brussels",

--- a/volunteer/tests/test_volunteer_shift_recurrent_subscription_participation.py
+++ b/volunteer/tests/test_volunteer_shift_recurrent_subscription_participation.py
@@ -23,7 +23,7 @@ class TestVolunteerShiftRecurrentSubscriptionParticipation(
         even if the generator has shift generated beyond the subscription end_date.
         """
         # Generator start_date is 2025/01/01,
-        # last shift generated is 2025/01/10 (10 occurrences)
+        # last shift generated is 2025/01/11 (10 occurrences, starting from 2025-01-02)
         self.gen_today_to_infinite_empty.write(
             {
                 "state": "confirmed",
@@ -61,7 +61,7 @@ class TestVolunteerShiftRecurrentSubscriptionParticipation(
                 ("generator_id", "=", self.gen_today_to_infinite_empty.id),
             ]
         )
-        self.assertEqual(len(shifts_beyond), 2)
+        self.assertEqual(len(shifts_beyond), 3)
         parts_beyond = self.Participation.search(
             [
                 ("shift_id", "in", shifts_beyond.ids),

--- a/volunteer/tests/test_volunteer_shift_recurrent_subscription_participation.py
+++ b/volunteer/tests/test_volunteer_shift_recurrent_subscription_participation.py
@@ -215,9 +215,35 @@ class TestVolunteerShiftRecurrentSubscriptionParticipation(
         )
         self.assertEqual(len(recurrent_part), 1)
 
-    def test_managing_cancel_or_create_participation(self):
-        """Test managing canceling or creating participation when modifying
-        a subscription end_date including setting it to None (no end)."""
+    def _check_existing_recurrent_participation_state_for_days(
+        self, generator, volunteer, days, state
+    ):
+        """Helper to check the state of volunteer's participation
+        for given generator and iterable days.
+        """
+        for day in days:
+            shift = self.Shift.search(
+                [
+                    ("start_time", "=", datetime(2025, 1, day, 10, 5)),
+                    ("generator_id", "=", generator.id),
+                ],
+                limit=1,
+            )
+            self.assertTrue(shift)
+            part = self.Participation.search(
+                [
+                    ("shift_id", "=", shift.id),
+                    ("volunteer_id", "=", volunteer.id),
+                    ("registration_type", "=", "recurrent"),
+                    ("registration_state", "=", state),
+                ]
+            )
+            self.assertEqual(len(part), 1)
+
+    def test_reducing_subscription_creates_no_duplicate_participation(self):
+        """Test that reducing subscription end_date modifies participation state
+        without creating duplicate records.
+        """
         self.gen_today_to_infinite_empty.with_user(self.user_admin).write(
             {"state": "confirmed"}
         )
@@ -235,7 +261,8 @@ class TestVolunteerShiftRecurrentSubscriptionParticipation(
                 ("generator_id", "=", self.gen_today_to_infinite_empty.id),
             ]
         )
-        part_8_confirmed = self.Participation.search(
+        # Check initial state
+        part_8_before_write = self.Participation.search(
             [
                 ("shift_id", "=", shift_8.id),
                 ("volunteer_id", "=", self.volunteer_test.id),
@@ -243,46 +270,226 @@ class TestVolunteerShiftRecurrentSubscriptionParticipation(
                 ("registration_state", "=", "confirmed"),
             ]
         )
-        self.assertEqual(len(part_8_confirmed), 1)
+        self.assertEqual(len(part_8_before_write), 1)
         # Reduce end date to 2025-01-07
         # needs to cancel participation on 2025-01-08
         sub.write({"end_date": date(2025, 1, 7)})
-        part_8_canceled = self.Participation.search(
+        part_8_after_write = self.Participation.search(
             [
                 ("shift_id", "=", shift_8.id),
                 ("volunteer_id", "=", self.volunteer_test.id),
                 ("registration_type", "=", "recurrent"),
-                ("registration_state", "=", "canceled"),
             ]
         )
         # Check that participation for shift on 2025-01-08 is canceled
-        # and there is no other confirmed participation for this shift
-        # and volunteer
-        self.assertEqual(len(part_8_canceled), 1)
-        part_8 = self.Participation.search(
-            [
-                ("shift_id", "=", shift_8.id),
-                ("volunteer_id", "=", self.volunteer_test.id),
-                ("registration_type", "=", "recurrent"),
-                ("registration_state", "=", "confirmed"),
-            ]
+        # and there is no other participation for this shift and volunteer
+        self.assertEqual(len(part_8_after_write), 1)
+        self.assertEqual(part_8_after_write.id, part_8_before_write.id)
+        self.assertEqual(part_8_after_write.registration_state, "canceled")
+
+    def test_extending_subscription_to_infinite(self):
+        """Test that extending subscription to infinite generates participation
+        for all generated shifts."""
+        self.gen_today_to_infinite_empty.with_user(self.user_admin).write(
+            {"state": "confirmed"}
         )
-        self.assertEqual(len(part_8), 0)
-        # Modify end date to False (infinite)
-        # needs to create participation after 2025-01-08 (check 2025-01-10)
+        sub = self.Subscription.create(
+            {
+                "start_date": date(2025, 1, 2),
+                "end_date": date(2025, 1, 2),
+                "volunteer_id": self.volunteer_test.id,
+                "generator_id": self.gen_today_to_infinite_empty.id,
+            }
+        )
         sub.write({"end_date": False})
-        shift_10 = self.Shift.search(
-            [
-                ("start_time", "=", datetime(2025, 1, 10, 10, 5)),
-                ("generator_id", "=", self.gen_today_to_infinite_empty.id),
-            ]
+        self._check_existing_recurrent_participation_state_for_days(
+            self.gen_today_to_infinite_empty,
+            self.volunteer_test,
+            range(2, 12),
+            "confirmed",
         )
-        part_10 = self.Participation.search(
+
+    def _run_intersection_test(self, generator):
+        """Helper to test intersection handling when modifying subscription.
+
+        Scenario:
+            Initial subscription: 2025-01-02 to 2025-01-06
+            Modified subscription: 2025-01-04 to 2025-01-08
+
+        Expected behavior:
+            - Intersection period (01-04 to 01-06): participation stay confirmed
+            - New period (01-07 to 01-08): participation are generated
+            - Old period (01-02 to 01-03): participation are canceled
+        """
+        generator.with_user(self.user_admin).write({"state": "confirmed"})
+        sub = self.Subscription.create(
+            {
+                "start_date": date(2025, 1, 2),
+                "end_date": date(2025, 1, 6),
+                "volunteer_id": self.volunteer_test.id,
+                "generator_id": generator.id,
+            }
+        )
+        # Move subscription from 01-02 to 01-06 to 01-04 to 01-08
+        # which creates an intersection between old and new subscription periods
+        # on 01-04 to 01-06
+        sub.write({"start_date": date(2025, 1, 4), "end_date": date(2025, 1, 8)})
+
+        # Intersection (01-04 to 01-06) needs to stay unchanged (confirmed)
+        self._check_existing_recurrent_participation_state_for_days(
+            generator,
+            self.volunteer_test,
+            range(4, 7),
+            "confirmed",
+        )
+        # New period outside intersection (01-07 to 01-08) needs to be generated
+        self._check_existing_recurrent_participation_state_for_days(
+            generator,
+            self.volunteer_test,
+            range(7, 9),
+            "confirmed",
+        )
+        # Old period outside intersection (01-02 to 01-03) needs to be canceled
+        self._check_existing_recurrent_participation_state_for_days(
+            generator,
+            self.volunteer_test,
+            range(2, 4),
+            "canceled",
+        )
+
+    def test_managing_cancel_create_participation_intersection_single_day(self):
+        """Test intersection handling with single-day shifts."""
+        self._run_intersection_test(self.gen_today_to_infinite_empty)
+
+    def test_managing_cancel_create_participation_intersection_multi_day(self):
+        """Test intersection handling with multi-day shifts."""
+        self._run_intersection_test(self.gen_shift_2_days)
+
+    def _run_no_intersection_test(self, generator):
+        """Helper to test full replacement when modifying subscription.
+
+        Scenario:
+            Initial subscription: 2025-01-02 to 2025-01-06
+            Modified subscription: 2025-01-07 to 2025-01-10
+
+        Expected behavior:
+            - New period (01-07 to 01-10): participation are generated
+            - Old period (01-02 to 01-06): participation are canceled
+        """
+        generator.with_user(self.user_admin).write({"state": "confirmed"})
+        sub = self.Subscription.create(
+            {
+                "start_date": date(2025, 1, 2),
+                "end_date": date(2025, 1, 6),
+                "volunteer_id": self.volunteer_test.id,
+                "generator_id": generator.id,
+            }
+        )
+        # Full replacement (no intersection) of the subscription
+        # from 01-02 to 01-06 to 01-07 to 01-10
+        sub.write({"start_date": date(2025, 1, 7), "end_date": date(2025, 1, 10)})
+        # New period needs to be generated (01-07 to 01-10)
+        self._check_existing_recurrent_participation_state_for_days(
+            generator,
+            self.volunteer_test,
+            range(7, 11),
+            "confirmed",
+        )
+        # Old period needs to be canceled (01-02 to 01-06)
+        self._check_existing_recurrent_participation_state_for_days(
+            generator,
+            self.volunteer_test,
+            range(2, 7),
+            "canceled",
+        )
+
+    def test_managing_cancel_create_participation_no_intersection_single_day(self):
+        """Test full replacement with single-day shifts."""
+        self._run_no_intersection_test(self.gen_today_to_infinite_empty)
+
+    def test_managing_cancel_create_participation_no_intersection_multi_day(self):
+        """Test full replacement with multi-day shifts."""
+        self._run_no_intersection_test(self.gen_shift_2_days)
+
+    def test_multi_day_shift_generation(self):
+        """Test that participation for multi-day shifts are generated when the subscription
+        stops on first day of the shift, without covering the end of the shift on other day.
+
+        Example:
+            Shift multiday (2025-01-02 to 2025-01-03), subscription starts 2025-01-02,
+            should generate participation for the shift of 2025-01-02,
+            even if the shift extends beyond this day (2025-01-03).
+        """
+        self.gen_shift_2_days.with_user(self.user_admin).write({"state": "confirmed"})
+        # Create a subscription ending on the same day as the start of the shift
+        self.Subscription.create(
+            {
+                "start_date": date(2025, 1, 2),
+                "end_date": date(2025, 1, 2),
+                "volunteer_id": self.volunteer_test.id,
+                "generator_id": self.gen_shift_2_days.id,
+            }
+        )
+        shift = self.Shift.search(
             [
-                ("shift_id", "=", shift_10.id),
+                ("start_time", "=", datetime(2025, 1, 2, 10, 5)),
+                ("generator_id", "=", self.gen_shift_2_days.id),
+            ],
+            limit=1,
+        )
+        self.assertTrue(shift)
+        self.assertNotEqual(shift.start_time.date(), shift.end_time.date())
+        part = self.Participation.search(
+            [
+                ("shift_id", "=", shift.id),
                 ("volunteer_id", "=", self.volunteer_test.id),
                 ("registration_type", "=", "recurrent"),
                 ("registration_state", "=", "confirmed"),
             ]
         )
-        self.assertEqual(len(part_10), 1)
+        self.assertEqual(len(part), 1)
+
+    def test_subscription_starts_after_first_day_of_multiday_shift(self):
+        """Test that a subscription starting after the first day of a multi-day shift
+        does not create participation (shift started before subscription).
+
+        Example:
+            Shift multiday (2025-01-02 to 2025-01-03), subscription starts 2025-01-03,
+            should not have participation for the shift of 2025-01-02.
+        """
+        self.gen_shift_2_days.with_user(self.user_admin).write({"state": "confirmed"})
+        # Subscription starts on the end day of shift 01-03
+        self.Subscription.create(
+            {
+                "start_date": date(2025, 1, 3),
+                "end_date": date(2025, 1, 10),
+                "volunteer_id": self.volunteer_test.id,
+                "generator_id": self.gen_shift_2_days.id,
+            }
+        )
+        # No participation should be created on 01-02
+        # (shift started before subscription)
+        shift = self.Shift.search(
+            [
+                ("start_time", "=", datetime(2025, 1, 2, 10, 5)),
+                ("generator_id", "=", self.gen_shift_2_days.id),
+            ],
+            limit=1,
+        )
+        self.assertTrue(shift)
+        part = self.Participation.search(
+            [
+                ("shift_id", "=", shift.id),
+                ("volunteer_id", "=", self.volunteer_test.id),
+                ("registration_type", "=", "recurrent"),
+                ("registration_state", "=", "confirmed"),
+            ]
+        )
+        self.assertEqual(len(part), 0)
+        # Participation should exist for shifts starting from 01-03
+        self._check_existing_recurrent_participation_state_for_days(
+            self.gen_shift_2_days,
+            self.volunteer_test,
+            range(3, 11),
+            "confirmed",
+        )


### PR DESCRIPTION
## Description

This PR fixes multi-day shift handling in subscription management by  using the shift's start_date instead of end_date as reference. This  ensures multi-day shifts are included when they start within the  subscription period, even if they extend beyond.

Additionally, the definition of "future shifts" is corrected to exclude today and start from tomorrow.


## Odoo task (if applicable)



## Checklist before approval

- [X] Tests are present (or not needed).
- [X] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [X] (If a new module) Moving this to OCA has been considered.
