### PR TITLE
[16.0][FIX] pos_eater: linter errors

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v2.3.1
+_commit: v2.3.2
 _src_path: https://github.com/coopiteasy/oca-addons-repo-template.git
 ci: GitHub
 convert_readme_fragments_to_markdown: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -140,7 +140,7 @@ repos:
           - --settings=.
         exclude: /__init__\.py$
   - repo: https://github.com/acsone/setuptools-odoo
-    rev: 3.1.8
+    rev: 3.3.2
     hooks:
       - id: setuptools-odoo-make-default
       - id: setuptools-odoo-get-requirements

--- a/pos_eater/static/src/js/ActionpadWidget.esm.js
+++ b/pos_eater/static/src/js/ActionpadWidget.esm.js
@@ -3,10 +3,10 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import Registries from "point_of_sale.Registries";
 import ActionpadWidget from "point_of_sale.ActionpadWidget";
+import Registries from "point_of_sale.Registries";
 
-const EaterActionpadWidget = (ActionpadWidget) =>
+const EaterActionpadWidget = () =>
     class extends ActionpadWidget {
         get eaterNames() {
             const names = this.props.partner.child_eater_ids.map(


### PR DESCRIPTION
It tries to solve theses linter errors:

pos_eater/static/src/js/ActionpadWidget.esm.js
  7:1   warning  Imports should be sorted alphabetically                                      sort-imports
  9:31  warning  'ActionpadWidget' is already declared in the upper scope on line 7 column 8  no-shadow

## Description



## Odoo task (if applicable)



## Checklist before approval

- [ ] Tests are present (or not needed).
- [ ] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [ ] (If a new module) Moving this to OCA has been considered.
