### PR TITLE
[16.0][ADD] volunteer: Add generator write permissions

### DIFF
--- a/volunteer/models/volunteer_shift_recurrent_generator.py
+++ b/volunteer/models/volunteer_shift_recurrent_generator.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models
-from odoo.exceptions import UserError, ValidationError
+from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.tools.translate import _
 
 
@@ -124,6 +124,7 @@ class VolunteerShiftRecurrentGenerator(models.Model):
 
     def write(self, vals):
         old_states = {generator.id: generator.state for generator in self}
+        self._check_write_permissions_based_on_state(vals, old_states)
         res = super().write(vals)
         for generator in self:
             previous_state = old_states[generator.id]
@@ -135,6 +136,92 @@ class VolunteerShiftRecurrentGenerator(models.Model):
         return res
 
     # Methods
+
+    def _check_write_permissions_based_on_state(self, vals, old_states):
+        """Check write permissions based on the generator state.
+
+        Note: access for user groups is managed by access rules
+        """
+        # Bypass checks during installation for demo data loading
+        if self.env.context.get("install_mode"):
+            return True
+        is_admin = self.env.user.has_group("volunteer.volunteer_group_admin")
+        if "state" in vals and not is_admin:
+            raise AccessError(_("Only admins can change the state of a generator"))
+        is_manager = self.env.user.has_group("volunteer.volunteer_group_manager")
+        for generator in self:
+            previous_state = old_states[generator.id]
+            target_state = vals.get("state") or generator.state
+            is_state_changing = previous_state != target_state
+            is_write_or_create_sub = bool(vals.get("volunteer_subscription_ids"))
+            is_only_managing_sub = is_write_or_create_sub and len(vals) == 1
+            if not is_state_changing:
+                if target_state == "draft":
+                    # Only admins can modify fields, managers can only manage subscriptions
+                    if not is_admin and not (is_manager and is_only_managing_sub):
+                        raise AccessError(
+                            _("Only admins can modify generators in draft.")
+                        )
+                elif target_state == "confirmed":
+                    # Restrict field changes for all groups (shifts already generated)
+                    # but subscription management remains allowed for
+                    # managers and admins
+                    if not (is_manager or is_admin) or not is_only_managing_sub:
+                        procedure_msg = (
+                            generator._get_message_procedure_to_modify_generator_fields()
+                        )
+                        raise UserError(
+                            _(
+                                "Modification of fields of a generators in confirmed state "
+                                "needs to be done by a specific procedure."
+                            )
+                            + procedure_msg
+                        )
+                elif target_state == "canceled":
+                    # Change on canceled state is not allowed for all groups
+                    raise UserError(
+                        _("It is not possible to modify a canceled generator.")
+                    )
+            else:  # State is changing
+                # Unauthorize return to state draft for all groups
+                if previous_state != "draft" and target_state == "draft":
+                    raise UserError(_("Returning to draft state is not allowed."))
+                # Unauthorize return from canceled state
+                if previous_state == "canceled" and target_state != "canceled":
+                    raise UserError(
+                        _(
+                            "It is not possible to change the state of a canceled generator."
+                        )
+                    )
+                # Admin is allowed to change state to canceled
+                # but not modify other fields or managed subscriptions at the same time
+                if (
+                    previous_state != "canceled" and target_state == "canceled"
+                ) and len(vals) != 1:
+                    raise UserError(
+                        _(
+                            "It is not possible to modify fields or manage subscriptions "
+                            "when canceling a generator."
+                        )
+                    )
+        return True
+
+    def _get_message_procedure_to_modify_generator_fields(self):
+        """Get the message explaining the procedure to modify restricted fields
+        or indicate to contact the administrator"""
+        if self.env.user.has_group("volunteer.volunteer_group_admin"):
+            custom_message = _(
+                "\nTo modify generator:\n"
+                "- Duplicate the generator and set the start time to today (or later)\n"
+                "- Apply the changes and re-add old subscriptions if needed\n"
+                "- Confirm the new generator, then cancel the original one.\n"
+            )
+        else:
+            custom_message = _(
+                "\nContact your administrator to make this change by "
+                "applying the requested procedure."
+            )
+        return custom_message
 
     def _get_interval_delta(self):
         """Get the interval delta for the generator"""

--- a/volunteer/models/volunteer_shift_recurrent_generator.py
+++ b/volunteer/models/volunteer_shift_recurrent_generator.py
@@ -336,8 +336,7 @@ class VolunteerShiftRecurrentGenerator(models.Model):
             {"stage_id": self.env.ref("volunteer.volunteer_shift_stage_canceled").id}
         )
         # Set until_date to today using super to avoid write recursion
-        # (future validations will be added to write method
-        # and need to be bypassed)
+        # and bypass write permission check to allow fields modification on canceled generator
         res = super(VolunteerShiftRecurrentGenerator, self).write({"until_date": today})
         return res
 

--- a/volunteer/tests/__init__.py
+++ b/volunteer/tests/__init__.py
@@ -10,6 +10,8 @@ from . import test_volunteer_shift_participation
 from . import test_volunteer_shift_recurrent_generator_generation
 from . import test_volunteer_shift_recurrent_generator_cancellation
 from . import test_volunteer_shift_recurrent_generator_dates_constraints
+from . import test_volunteer_shift_recurrent_generator_state_change_permissions
+from . import test_volunteer_shift_recurrent_generator_write_permissions
 from . import test_volunteer_shift_recurrent_subscription
 from . import test_volunteer_shift_recurrent_subscription_cancellation
 from . import test_volunteer_shift_recurrent_subscription_dates_constraints

--- a/volunteer/tests/test_volunteer_common.py
+++ b/volunteer/tests/test_volunteer_common.py
@@ -29,6 +29,7 @@ class TestVolunteerCommon(common.TransactionCase):
         # Models
         self.Shift = self.env["volunteer.shift"]
         self.Type = self.env["volunteer.shift.type"]
+        self.Category = self.env["volunteer.shift.category"]
         self.Volunteer = self.env["volunteer.volunteer"]
         self.Participation = self.env["volunteer.shift.participation"]
         self.Generator = self.env["volunteer.shift.recurrent.generator"]
@@ -60,6 +61,14 @@ class TestVolunteerCommon(common.TransactionCase):
             {
                 "name": "TypeTest",
                 "description": "Type for autotests",
+            }
+        )
+
+        # Create category
+        self.category_test = self.Category.create(
+            {
+                "name": "CategoryTest",
+                "description": "Category for autotests",
             }
         )
 

--- a/volunteer/tests/test_volunteer_shift_recurrent_generator_state_change_permissions.py
+++ b/volunteer/tests/test_volunteer_shift_recurrent_generator_state_change_permissions.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2025 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from freezegun import freeze_time
+
+from odoo.exceptions import UserError
+
+from .test_volunteer_generator_subscription_common import (
+    TestVolunteerGeneratorSubscriptionCommon,
+)
+
+
+@freeze_time("2025-01-01 10:00:00")
+class TestVolunteerShiftRecurrentGeneratorStateChangePermissions(
+    TestVolunteerGeneratorSubscriptionCommon
+):
+    def setUp(self):
+        super().setUp()
+
+    def test_manager_cannot_write_generator_state(self):
+        """Test that manager cannot change the state of a generator."""
+        with self.assertRaises(UserError):
+            self.gen_today_to_infinite_empty.with_user(self.user_manager).write(
+                {
+                    "state": "confirmed",
+                }
+            )
+
+    def test_cannot_go_back_to_draft_state_from_confirmed(self):
+        """Test it is not possible to go back to draft state for generator,
+        from confirmed state."""
+        self.gen_today_to_infinite_empty.write(
+            {
+                "state": "confirmed",
+            }
+        )
+        with self.assertRaises(UserError):
+            self.gen_today_to_infinite_empty.write(
+                {
+                    "state": "draft",
+                }
+            )
+
+    def test_cannot_go_back_to_draft_state_from_canceled(self):
+        """Test it is not possible to go back to draft state for generator
+        from canceled state."""
+        self.gen_today_to_infinite_empty.write(
+            {
+                "state": "canceled",
+            }
+        )
+        with self.assertRaises(UserError):
+            self.gen_today_to_infinite_empty.write(
+                {
+                    "state": "draft",
+                }
+            )
+
+    def test_cannot_change_state_of_canceled_generator(self):
+        """Test it is not possible to change the state of a canceled generator."""
+        self.gen_today_to_infinite_empty.write(
+            {
+                "state": "canceled",
+            }
+        )
+        with self.assertRaises(UserError):
+            self.gen_today_to_infinite_empty.write(
+                {
+                    "state": "confirmed",
+                }
+            )

--- a/volunteer/tests/test_volunteer_shift_recurrent_generator_write_permissions.py
+++ b/volunteer/tests/test_volunteer_shift_recurrent_generator_write_permissions.py
@@ -1,0 +1,288 @@
+# SPDX-FileCopyrightText: 2025 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from datetime import date
+
+from freezegun import freeze_time
+
+from odoo import Command
+from odoo.exceptions import AccessError, UserError
+
+from .test_volunteer_generator_subscription_common import (
+    TestVolunteerGeneratorSubscriptionCommon,
+)
+
+
+@freeze_time("2025-01-01 10:00:00")
+class TestVolunteerShiftRecurrentGeneratorWritePermissions(
+    TestVolunteerGeneratorSubscriptionCommon
+):
+    """Test write field permissions of shift recurrent generator,
+    and subscription management via notebook, depending on generator state and role.
+
+    Note: user group is readonly on generators and subscriptions via access rules.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+    # Draft generator fields write permissions
+
+    def test_admin_can_write_field_on_draft_generator(self):
+        self.gen_today_to_infinite_empty.with_user(self.user_admin).write(
+            {
+                "category_id": self.category_test.id,
+            }
+        )
+
+    def test_manager_cannot_write_field_on_draft_generator(self):
+        with self.assertRaises(AccessError):
+            self.gen_today_to_infinite_empty.with_user(self.user_manager).write(
+                {
+                    "category_id": self.category_test.id,
+                }
+            )
+
+    # Subscription write permissions for draft generator
+
+    def test_manager_can_write_subscriptions_on_draft_generator(self):
+        self.gen_ongoing_with_3_subs.with_user(self.user_manager).write(
+            {
+                "volunteer_subscription_ids": [
+                    Command.update(
+                        self.sub_upcoming.id,
+                        {
+                            "start_date": date(2025, 1, 3),
+                            "end_date": date(2025, 1, 4),
+                        },
+                    )
+                ]
+            }
+        )
+
+    # Confirmed generator fields write permissions
+
+    def test_manager_cannot_write_fields_on_confirmed_generator(self):
+        self.gen_today_to_infinite_empty.with_user(self.user_admin).write(
+            {
+                "state": "confirmed",
+            }
+        )
+        with self.assertRaises(UserError):
+            self.gen_today_to_infinite_empty.with_user(self.user_manager).write(
+                {"category_id": self.category_test.id}
+            )
+
+    def test_admin_cannot_write_fields_on_confirmed_generator(self):
+        self.gen_today_to_infinite_empty.with_user(self.user_admin).write(
+            {
+                "state": "confirmed",
+            }
+        )
+        with self.assertRaises(UserError):
+            self.gen_today_to_infinite_empty.with_user(self.user_admin).write(
+                {"category_id": self.category_test.id}
+            )
+
+    # Subscription write permissions for confirmed generator
+
+    def test_manager_can_write_subscriptions_on_confirmed_generator(self):
+        self.gen_ongoing_with_3_subs.with_user(self.user_admin).write(
+            {
+                "state": "confirmed",
+            }
+        )
+        self.gen_ongoing_with_3_subs.with_user(self.user_manager).write(
+            {
+                "volunteer_subscription_ids": [
+                    Command.update(
+                        self.sub_upcoming.id,
+                        {
+                            "start_date": date(2025, 1, 3),
+                            "end_date": date(2025, 1, 4),
+                        },
+                    )
+                ]
+            }
+        )
+
+    def test_manager_cannot_write_subscriptions_and_write_fields_on_confirmed_generator(
+        self,
+    ):
+        """Test that modifying confirmed generator fields while managing subscription
+        is not allowed for manager"""
+        self.gen_ongoing_with_3_subs.with_user(self.user_admin).write(
+            {
+                "state": "confirmed",
+            }
+        )
+        with self.assertRaises(UserError):
+            self.gen_ongoing_with_3_subs.with_user(self.user_manager).write(
+                {
+                    "category_id": self.category_test.id,
+                    "volunteer_subscription_ids": [
+                        Command.update(
+                            self.sub_upcoming.id,
+                            {
+                                "start_date": date(2025, 1, 3),
+                                "end_date": date(2025, 1, 4),
+                            },
+                        )
+                    ],
+                }
+            )
+
+    def test_admin_can_write_subscriptions_on_confirmed_generator(self):
+        self.gen_ongoing_with_3_subs.with_user(self.user_admin).write(
+            {
+                "state": "confirmed",
+            }
+        )
+        self.gen_ongoing_with_3_subs.with_user(self.user_admin).write(
+            {
+                "volunteer_subscription_ids": [
+                    Command.update(
+                        self.sub_upcoming.id,
+                        {
+                            "start_date": date(2025, 1, 3),
+                            "end_date": date(2025, 1, 4),
+                        },
+                    )
+                ]
+            }
+        )
+
+    def test_admin_cannot_write_subscriptions_and_fields_on_confirmed_generator(self):
+        """Test that modifying confirmed generator fields while managing subscription
+        is not allowed for admin"""
+        self.gen_ongoing_with_3_subs.with_user(self.user_admin).write(
+            {
+                "state": "confirmed",
+            }
+        )
+        with self.assertRaises(UserError):
+            self.gen_ongoing_with_3_subs.with_user(self.user_admin).write(
+                {
+                    "category_id": self.category_test.id,
+                    "volunteer_subscription_ids": [
+                        Command.update(
+                            self.sub_upcoming.id,
+                            {
+                                "start_date": date(2025, 1, 3),
+                                "end_date": date(2025, 1, 4),
+                            },
+                        )
+                    ],
+                }
+            )
+
+    # Canceled generator fields write permissions
+
+    def test_manager_cannot_write_fields_on_canceled_generator(self):
+        self.gen_today_to_infinite_empty.with_user(self.user_admin).write(
+            {
+                "state": "canceled",
+            }
+        )
+        with self.assertRaises(UserError):
+            self.gen_today_to_infinite_empty.with_user(self.user_manager).write(
+                {
+                    "category_id": self.category_test.id,
+                }
+            )
+
+    def test_admin_cannot_write_fields_on_canceled_generator(self):
+        self.gen_today_to_infinite_empty.with_user(self.user_admin).write(
+            {
+                "state": "canceled",
+            }
+        )
+        with self.assertRaises(UserError):
+            self.gen_today_to_infinite_empty.with_user(self.user_admin).write(
+                {
+                    "category_id": self.category_test.id,
+                }
+            )
+
+    def test_admin_cannot_write_fields_during_generator_cancellation(self):
+        """Test that modifying other fields while setting generator state
+        to canceled is not allowed"""
+        self.gen_today_to_infinite_empty.with_user(self.user_admin).write(
+            {
+                "state": "confirmed",
+            }
+        )
+        with self.assertRaises(UserError):
+            self.gen_today_to_infinite_empty.with_user(self.user_admin).write(
+                {
+                    "state": "canceled",
+                    "category_id": self.category_test.id,
+                }
+            )
+
+    # Write subscription permissions on canceled generator
+
+    def test_manager_cannot_write_subscription_on_canceled_generator(self):
+        self.gen_ongoing_with_3_subs.with_user(self.user_admin).write(
+            {
+                "state": "canceled",
+            }
+        )
+        with self.assertRaises(UserError):
+            self.gen_ongoing_with_3_subs.with_user(self.user_manager).write(
+                {
+                    "volunteer_subscription_ids": [
+                        Command.update(
+                            self.sub_upcoming.id,
+                            {
+                                "start_date": date(2025, 1, 3),
+                                "end_date": date(2025, 1, 4),
+                            },
+                        )
+                    ],
+                }
+            )
+
+    def test_admin_cannot_write_subscription_on_canceled_generator(self):
+        self.gen_ongoing_with_3_subs.with_user(self.user_admin).write(
+            {
+                "state": "canceled",
+            }
+        )
+        with self.assertRaises(UserError):
+            self.gen_ongoing_with_3_subs.with_user(self.user_admin).write(
+                {
+                    "volunteer_subscription_ids": [
+                        Command.update(
+                            self.sub_upcoming.id,
+                            {
+                                "start_date": date(2025, 1, 3),
+                                "end_date": date(2025, 1, 4),
+                            },
+                        )
+                    ],
+                }
+            )
+
+    # Procedure message to write field of confirmed generator
+
+    def test_admin_gets_procedure_message_on_confirmed_generator_modification(self):
+        self.gen_today_to_infinite_empty.with_user(self.user_admin).write(
+            {"state": "confirmed"}
+        )
+        with self.assertRaisesRegex(UserError, "Duplicate the generator"):
+            self.gen_today_to_infinite_empty.with_user(self.user_admin).write(
+                {"category_id": self.category_test.id}
+            )
+
+    def test_manager_gets_contact_admin_message_on_confirmed_generator_modification(
+        self,
+    ):
+        self.gen_today_to_infinite_empty.with_user(self.user_admin).write(
+            {"state": "confirmed"}
+        )
+        with self.assertRaisesRegex(UserError, "Contact your administrator"):
+            self.gen_today_to_infinite_empty.with_user(self.user_manager).write(
+                {"category_id": self.category_test.id}
+            )

--- a/volunteer/tests/test_volunteer_shift_recurrent_subscription_write_permissions.py
+++ b/volunteer/tests/test_volunteer_shift_recurrent_subscription_write_permissions.py
@@ -17,6 +17,13 @@ from .test_volunteer_generator_subscription_common import (
 class TestVolunteerShiftRecurrentSubscriptionWritePermissions(
     TestVolunteerGeneratorSubscriptionCommon
 ):
+    """Test date-based write permissions on shift recurrent subscription.
+
+    Note: Tests runs with admin role (defined in setup), admins (and managers)
+    are allowed to modify subscriptions with date-based restrictions,
+    except on canceled generators.
+    """
+
     def setUp(self):
         super().setUp()
 

--- a/volunteer/views/volunteer_shift_generator_views.xml
+++ b/volunteer/views/volunteer_shift_generator_views.xml
@@ -95,7 +95,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                             name="page_subscription_active"
                             string="Active Subscriptions"
                         >
-                            <field name="volunteer_subscription_ids">
+                            <field
+                                name="volunteer_subscription_ids"
+                                attrs="{'readonly': [('state', '=', 'canceled')]}"
+                            >
                                 <tree editable="bottom" delete="false">
                                     <field
                                         name="volunteer_id"

--- a/volunteer/views/volunteer_shift_generator_views.xml
+++ b/volunteer/views/volunteer_shift_generator_views.xml
@@ -117,6 +117,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                                         class="btn-danger float-end"
                                         confirm="Are you sure you want to cancel this subscription?"
                                         attrs="{'invisible': [('temporal_state', '=', 'finished')]}"
+                                        groups="volunteer.volunteer_group_manager,volunteer.volunteer_group_admin"
                                     />
                                 </tree>
                             </field>


### PR DESCRIPTION
## Description

This PR adds role-based write permissions for generators, covering field modifications, state transitions, and subscription management via the notebook.

State transition rules:
- Cannot return to draft from any state
- Cannot change state of a canceled generator
- Cannot modify other fields or subscriptions while canceling

Role-based field permissions:
- User: readonly via access rules
- Manager: 
	- cannot modify fields
	- cannot change state
	- can only manage subscriptions (create/update/cancel) on draft and confirmed generators
- Admin: 
	- can modify fields on draft generators
	- can change state when allowed
	- can manage subscriptions on draft and confirmed generators

Blocked for all on canceled generators:
- No field modification
- No subscription management

UI:
- Subscription cancel button hidden for user group
- Notebook readonly for canceled generator
- Procedure guidance message on confirmed generator field modification

Tests files added:
- test_volunteer_shift_recurrent_generator_state_change_permissions
- test_volunteer_shift_recurrent_generator_write_permissions


## Odoo task (if applicable)



## Checklist before approval

- [X] Tests are present (or not needed).
- [ ] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [x] (If a new module) Moving this to OCA has been considered.
