### PR TITLE
[12.0] [FIX] shift: ordering

### DIFF
--- a/shift/__manifest__.py
+++ b/shift/__manifest__.py
@@ -14,7 +14,7 @@
     ),
     "website": "https://github.com/beescoop/Obeesdoo",
     "category": "Cooperative management",
-    "version": "12.0.5.0.2",
+    "version": "12.0.5.0.3",
     "depends": ["mail"],
     "data": [
         "data/system_parameter.xml",

--- a/shift/models/cooperative_status.py
+++ b/shift/models/cooperative_status.py
@@ -25,7 +25,7 @@ class HistoryStatus(models.Model):
     _name = "cooperative.status.history"
     _description = "cooperative.status.history"
 
-    _order = "create_date desc"
+    _order = "create_date desc, cooperator_id, id"
 
     status_id = fields.Many2one("cooperative.status")
     cooperator_id = fields.Many2one("res.partner")
@@ -40,7 +40,7 @@ class CooperativeStatus(models.Model):
     _name = "cooperative.status"
     _description = "cooperative.status"
     _rec_name = "cooperator_id"
-    _order = "cooperator_id"
+    _order = "cooperator_id, id"
     _period = 28
 
     def _get_status(self):
@@ -505,7 +505,7 @@ class CooperativeStatus(models.Model):
 class ShiftCronJournal(models.Model):
     _name = "shift.journal"
     _description = "shift.journal"
-    _order = "date desc"
+    _order = "date desc, id"
     _rec_name = "date"
 
     date = fields.Date()

--- a/shift/models/planning.py
+++ b/shift/models/planning.py
@@ -31,6 +31,8 @@ class ShiftType(models.Model):
     _name = "shift.type"
     _description = "shift.type"
 
+    _order = "name, id"
+
     name = fields.Char()
     description = fields.Text()
     active = fields.Boolean(default=True)
@@ -40,7 +42,7 @@ class ShiftDayNumber(models.Model):
     _name = "shift.daynumber"
     _description = "shift.daynumber"
 
-    _order = "number asc"
+    _order = "number asc, id"
 
     name = fields.Char()
     number = fields.Integer(
@@ -55,7 +57,7 @@ class ShiftDayNumber(models.Model):
 class ShiftPlanning(models.Model):
     _name = "shift.planning"
     _description = "shift.planning"
-    _order = "sequence asc"
+    _order = "sequence asc, id"
 
     sequence = fields.Integer()
     name = fields.Char()
@@ -198,7 +200,7 @@ class ShiftPlanning(models.Model):
 class ShiftTemplate(models.Model):
     _name = "shift.template"
     _description = "shift.template"
-    _order = "start_time"
+    _order = "planning_id, task_type_id, start_time, id"
 
     name = fields.Char(required=True)
     planning_id = fields.Many2one("shift.planning", required=True)

--- a/shift/models/shift_shift.py
+++ b/shift/models/shift_shift.py
@@ -10,7 +10,7 @@ from odoo.tools.translate import _
 class ShiftShift(models.Model):
     _name = "shift.shift"
     _inherit = ["mail.thread"]
-    _order = "start_time asc"
+    _order = "start_time asc, task_template_id, task_type_id, worker_id, id"
 
     ##################################
     # Method to override             #

--- a/shift_attendance/tests/test_shift.py
+++ b/shift_attendance/tests/test_shift.py
@@ -336,6 +336,8 @@ class TestShift(TransactionCase):
         self.assertEqual(sheet_1.added_shift_ids[1].task_id.state, "done")
 
         # Empty shift should have been updated
-        self.assertEqual(sheet_1.added_shift_ids[0].task_id, self.shift_empty_1)
+        self.assertIn(
+            self.shift_empty_1, (rec.task_id for rec in sheet_1.added_shift_ids)
+        )
 
         # sheet_1.expected_shift_ids[0].worker_id


### PR DESCRIPTION
## Description

Models that have an `_order` parameter are not configured correctly.

There were configured only with fields that are not unique for the
model.

For example shift.template had `_order = "start_time"`. start_time
is not a unique field for shift.template. You can have several
shift.template with the same value for start_time.

If you fetch directly some shift.template, there is no issue. You get
shift.template ordered by start_time. And items with the same value for
start_time are returned in a random order. You can use the UI to sort or
filter them with other fields.

The issue occurs when you try to fetch some shift.shift and you want
them ordered by shift.template.
```python
shifts = self.env["shift.shift"].search([], _order="shift_template_id")
```
You assume that shifts will be grouped by shift.template. But as soon as
you have two shift.template with the same start_time, this is not the
case.

Odoo uses the _order specified on the model shift.template to
order shift.template in the request of shift.shift.

You get something suprising like this:
```
shift_id | shift_template_id | start_time
---------|-------------------|-----------
1        | 1                 | 10
2        | 2                 | 10
3        | 1                 | 10
4        | 1                 | 10
5        | 2                 | 10
6        | 3                 | 14
7        | 3                 | 14
```

In the example all the shift.template that have 10 as start_time are
considered equal. Therefore shift are not ordered by shift.template.

What we expect is the following result:
```
shift_id | shift_template_id | start_time
---------|-------------------|-----------
1        | 1                 | 10
3        | 1                 | 10
4        | 1                 | 10
2        | 2                 | 10
5        | 2                 | 10
6        | 3                 | 14
7        | 3                 | 14
```

To get this result it is important to set at least and in final position
a unique field in the _order attribute of the model. For example the id.

With `_order = "start_time, id"` in the model shift.template, we get the
right result.

This fix is applied to other models than the one exposed in this
example.

## Odoo task (if applicable)

[task](https://gestion.coopiteasy.be/web#id=15900&action=479&model=project.task&view_type=form&menu_id=536)

## Checklist before approval

- [x] Tests are present (or not needed).
- [x] Credits/copyright have been changed correctly.
- [ ] Change log snippet is present.
- [x] (If a new module) Moving this to OCA has been considered.
