### PR TITLE
[16.0][FIX] fix display of product quantity

### DIFF
--- a/beesdoo_print_label/views/report_pricetag_normal.xml
+++ b/beesdoo_print_label/views/report_pricetag_normal.xml
@@ -63,15 +63,17 @@
                             <!-- Weight (Kg) or Volume (L) pf the product -->
                             <div class="product_price_per_uom_qty">
                                 <t t-if="product_tmpl_id.volume">
-                                    <t t-out="product_tmpl_id.volume" /> <t
-                                        t-out="product_tmpl_id.display_unit.name"
-                                    />
+                                    <t
+                                        t-out="product_tmpl_id.volume"
+                                        t-options="{'widget': 'float', 'decimal_precision': 'Product Unit of Measure'}"
+                                    /> <t t-out="product_tmpl_id.display_unit.name" />
                                 </t>
 
                                 <t t-elif="product_tmpl_id.display_weight">
-                                    <t t-out="product_tmpl_id.display_weight" /> <t
-                                        t-out="product_tmpl_id.display_unit.name"
-                                    />
+                                    <t
+                                        t-out="product_tmpl_id.display_weight"
+                                        t-options="{'widget': 'float', 'decimal_precision': 'Product Unit of Measure'}"
+                                    /> <t t-out="product_tmpl_id.display_unit.name" />
                                 </t>
                             </div>
                             <!-- Price per Kg or L -->
@@ -82,8 +84,7 @@
                                 <t
                                     t-out="product_tmpl_id.total_with_vat_by_unit"
                                     t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
-                                />
-                                 / <t
+                                /> / <t
                                     t-out="product_tmpl_id.default_reference_unit.name"
                                 />
                             </div>


### PR DESCRIPTION
## description

* fix display of product quantity: use correct decimal separator and uom precision.
* remove extraneous (breaking) space in unit price display.

## odoo task

[t15933](https://gestion.coopiteasy.be/web#id=15933&model=project.task)