### PR TITLE
[16.0][FIX] pos_eater: fix missing class argument

### DIFF
--- a/pos_eater/static/src/js/ActionpadWidget.esm.js
+++ b/pos_eater/static/src/js/ActionpadWidget.esm.js
@@ -6,8 +6,8 @@
 import ActionpadWidget from "point_of_sale.ActionpadWidget";
 import Registries from "point_of_sale.Registries";
 
-const EaterActionpadWidget = () =>
-    class extends ActionpadWidget {
+const EaterActionpadWidget = (ActionpadWidget_) =>
+    class extends ActionpadWidget_ {
         get eaterNames() {
             const names = this.props.partner.child_eater_ids.map(
                 (id) => this.env.pos.db.get_partner_by_id(id).name


### PR DESCRIPTION
## description

fix missing class argument in `EaterActionpadWidget` (erroneously removed in #576).