### PR TITLE
[12.0] [FIX] shift: shift.template default order

### DIFF
--- a/shift/models/planning.py
+++ b/shift/models/planning.py
@@ -200,7 +200,7 @@ class ShiftPlanning(models.Model):
 class ShiftTemplate(models.Model):
     _name = "shift.template"
     _description = "shift.template"
-    _order = "planning_id, task_type_id, start_time, id"
+    _order = "planning_id, day_nb_id, start_time, task_type_id, id"
 
     name = fields.Char(required=True)
     planning_id = fields.Many2one("shift.planning", required=True)


### PR DESCRIPTION
## Description

shift.template are now ordered by:
1. Week (planning_id)
2. Day of the week (day_nb_id)
3. Time (start_time)
4. Task Type (task_type_id)

## Odoo task (if applicable)

[task](https://gestion.coopiteasy.be/web#id=16328&action=479&model=project.task&view_type=form&menu_id=536)

## Checklist before approval

- [x] Tests are present (or not needed).
- [x] Credits/copyright have been changed correctly.
- [x] Change log snippet is present.
- [x] (If a new module) Moving this to OCA has been considered.
