### PR TITLE
[12.0] [FIX] beesdoo_website_shift: empty shifts in portal

### DIFF
--- a/beesdoo_website_shift/controllers/main.py
+++ b/beesdoo_website_shift/controllers/main.py
@@ -449,7 +449,7 @@ class WebsiteShiftController(http.Controller):
             has_enough_workers = (
                 free_space <= (task_template.worker_nb * highlight_rule_pc) / 100
             )
-            if free_space >= task_template.worker_nb * hide_rule:
+            if free_space > 0 and free_space >= task_template.worker_nb * hide_rule:
                 displayed_shifts.append(
                     DisplayedShift(
                         shift_list[0],


### PR DESCRIPTION
## Description

Shifts is shown in case of free_space = 0 and hide_rule = 0. Which is not correct. Shift should only be shown if free_space > 0 and free_space >= special rules.

Fix in 16.0 is available in https://github.com/beescoop/Obeesdoo/pull/572.

## Odoo task (if applicable)

[task](https://gestion.coopiteasy.be/web#id=16390&action=479&model=project.task&view_type=form&menu_id=536)

## Checklist before approval

- [x] Tests are present (or not needed).
- [x] Credits/copyright have been changed correctly.
- [x] Change log snippet is present.
- [x] (If a new module) Moving this to OCA has been considered.
