### PR TITLE
[16.0][FIX] shift : hide parent name in kanban view

### DIFF
--- a/shift/models/planning.py
+++ b/shift/models/planning.py
@@ -272,7 +272,9 @@ class ShiftTemplate(models.Model):
     @api.depends("worker_ids")
     def _compute_worker_name(self):
         for rec in self:
-            rec.worker_name = ",".join(rec.worker_ids.mapped("display_name"))
+            # name rather than display_name, so the parent doesn't appear
+            # on worker list in kanban
+            rec.worker_name = ",".join(rec.worker_ids.mapped("name"))
 
     @api.constrains("worker_nb", "worker_ids")
     def _nb_worker_max(self):


### PR DESCRIPTION
## Description

Replace display_name by name for workers list, so that in kanban view parent partner doesn't appear in the list.

## Odoo task (if applicable)

[16701](https://gestion.coopiteasy.be/web#id=16701&action=479&model=project.task&view_type=form&menu_id=536)

## Checklist before approval

- [x] Tests are present (or not needed).
- [x] Credits/copyright have been changed correctly.
- [x] Change log snippet is present.
- [x] (If a new module) Moving this to OCA has been considered.
