### PR TITLE
[FIX] fixed wrong check for change time limit

### DIFF
--- a/shift_change/i18n/fr.po
+++ b/shift_change/i18n/fr.po
@@ -8,10 +8,11 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: \n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. module: shift_change
 #: model_terms:ir.ui.view,arch_db:shift_change.res_config_settings_swap_view_form
@@ -20,6 +21,10 @@ msgid ""
 "                                Maximum changes for the same shift\n"
 "                            </span>"
 msgstr ""
+"<span class=\"o_form_label\">\n"
+"                                Nombre maximum de changements pour le même "
+"shift\n"
+"                            </span>"
 
 #. module: shift_change
 #: model_terms:ir.ui.view,arch_db:shift_change.res_config_settings_swap_view_form
@@ -28,6 +33,9 @@ msgid ""
 "                                Time limit to change a shift\n"
 "                            </span>"
 msgstr ""
+"<span class=\"o_form_label\">\n"
+"                                Limite de temps pour changer un shift\n"
+"                            </span>"
 
 #. module: shift_change
 #: model_terms:ir.ui.view,arch_db:shift_change.res_config_settings_swap_view_form
@@ -36,6 +44,10 @@ msgid ""
 "                                Time limit to take a new shift\n"
 "                            </span>"
 msgstr ""
+"<span class=\"o_form_label\">\n"
+"                                Limite de temps pour participer à un nouveau "
+"shift\n"
+"                            </span>"
 
 #. module: shift_change
 #: model:ir.model,name:shift_change.model_shift_change
@@ -45,12 +57,12 @@ msgstr ""
 #. module: shift_change
 #: model:ir.model.fields,field_description:shift_change.field_shift_change_create_wizard__available_new_shift_ids
 msgid "Available New Shifts"
-msgstr ""
+msgstr "Nouveaux shifts disponibles"
 
 #. module: shift_change
 #: model_terms:ir.ui.view,arch_db:shift_change.shift_change_create_wizard_form
 msgid "Cancel"
-msgstr ""
+msgstr "Annuler"
 
 #. module: shift_change
 #. odoo-python
@@ -58,7 +70,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:shift_change.res_partner_shift_change_button
 #, python-format
 msgid "Change a Shift"
-msgstr ""
+msgstr "Changer un shift"
 
 #. module: shift_change
 #: model:ir.model,name:shift_change.model_res_config_settings
@@ -68,7 +80,7 @@ msgstr ""
 #. module: shift_change
 #: model_terms:ir.ui.view,arch_db:shift_change.shift_change_create_wizard_form
 msgid "Confirm"
-msgstr ""
+msgstr "Confirmer"
 
 #. module: shift_change
 #: model:ir.model,name:shift_change.model_res_partner
@@ -85,19 +97,19 @@ msgstr ""
 #: model:ir.ui.menu,name:shift_change.menu_shift_change_create_wizard
 #: model_terms:ir.ui.view,arch_db:shift_change.shift_change_create_wizard_form
 msgid "Create Shift Change"
-msgstr ""
+msgstr "Créer un changement de shift"
 
 #. module: shift_change
 #: model:ir.model.fields,field_description:shift_change.field_shift_change__create_uid
 #: model:ir.model.fields,field_description:shift_change.field_shift_change_create_wizard__create_uid
 msgid "Created by"
-msgstr ""
+msgstr "Créé par"
 
 #. module: shift_change
 #: model:ir.model.fields,field_description:shift_change.field_shift_change__create_date
 #: model:ir.model.fields,field_description:shift_change.field_shift_change_create_wizard__create_date
 msgid "Created on"
-msgstr ""
+msgstr "Créé le"
 
 #. module: shift_change
 #: model:ir.model.fields,field_description:shift_change.field_shift_change__display_name
@@ -113,7 +125,7 @@ msgstr ""
 #. module: shift_change
 #: model_terms:ir.ui.view,arch_db:shift_change.res_config_settings_swap_view_form
 msgid "Hours"
-msgstr ""
+msgstr "Heures"
 
 #. module: shift_change
 #: model:ir.model.fields,field_description:shift_change.field_shift_change__id
@@ -142,13 +154,13 @@ msgstr ""
 #. module: shift_change
 #: model_terms:ir.ui.view,arch_db:shift_change.shift_change_view_search
 msgid "My Changes"
-msgstr ""
+msgstr "Mes changements"
 
 #. module: shift_change
 #: model:ir.model.fields,field_description:shift_change.field_shift_change__new_shift_id
 #: model:ir.model.fields,field_description:shift_change.field_shift_change_create_wizard__new_shift_id
 msgid "New Shift"
-msgstr ""
+msgstr "Nouveau shift"
 
 #. module: shift_change
 #: model:ir.model.fields,field_description:shift_change.field_res_config_settings__new_shift_hour_limit_change
@@ -159,22 +171,25 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:shift_change.res_config_settings_swap_view_form
 msgid "Number of hours below which a new shift cannot be taken"
 msgstr ""
+"Nombre d'heures en-dessous desquelles il n'est plus possible de s'inscrire à "
+"un nouveau shift"
 
 #. module: shift_change
 #: model_terms:ir.ui.view,arch_db:shift_change.res_config_settings_swap_view_form
 msgid "Number of hours below which a shift cannot be changed"
 msgstr ""
+"Nombre d'heures en-dessous desquelles un shift ne peut plus être changé"
 
 #. module: shift_change
 #: model_terms:ir.ui.view,arch_db:shift_change.res_config_settings_swap_view_form
 msgid "Number of time the same shift can be changed"
-msgstr ""
+msgstr "Nombre de fois qu'un même shift peut être changé"
 
 #. module: shift_change
 #: model:ir.model.fields,field_description:shift_change.field_shift_change__old_shift_id
 #: model:ir.model.fields,field_description:shift_change.field_shift_change_create_wizard__old_shift_id
 msgid "Old Shift"
-msgstr ""
+msgstr "Ancien shift"
 
 #. module: shift_change
 #: model:ir.model.fields,field_description:shift_change.field_res_config_settings__old_shift_hour_limit_change
@@ -191,17 +206,17 @@ msgstr ""
 #: model:ir.ui.menu,name:shift_change.menu_change_top
 #: model_terms:ir.ui.view,arch_db:shift_change.res_config_settings_swap_view_form
 msgid "Shift Changes"
-msgstr ""
+msgstr "Changements de shift"
 
 #. module: shift_change
 #: model:ir.ui.menu,name:shift_change.menu_change
 msgid "Shift Changes History"
-msgstr ""
+msgstr "Historique de changements de shift"
 
 #. module: shift_change
 #: model_terms:ir.ui.view,arch_db:shift_change.res_config_settings_swap_view_form
 msgid "Times"
-msgstr ""
+msgstr "Fois"
 
 #. module: shift_change
 #: model:ir.model,name:shift_change.model_shift_change_create_wizard
@@ -213,28 +228,28 @@ msgstr ""
 #: model:ir.model.fields,field_description:shift_change.field_shift_change_create_wizard__worker_id
 #: model_terms:ir.ui.view,arch_db:shift_change.shift_change_view_search
 msgid "Worker"
-msgstr ""
+msgstr "Travailleur"
 
 #. module: shift_change
 #. odoo-python
 #: code:addons/shift_change/models/shift_change.py:0
 #, python-format
 msgid "You can't change a shift that is in the past."
-msgstr ""
+msgstr "Vous ne pouvez pas changer un shift qui est dans le passé."
 
 #. module: shift_change
 #. odoo-python
 #: code:addons/shift_change/models/shift_change.py:0
 #, python-format
 msgid "You can't change a shift that is so close in the future."
-msgstr ""
+msgstr "Vous ne pouvez pas changer un shift qui est si proche dans le temps."
 
 #. module: shift_change
 #. odoo-python
 #: code:addons/shift_change/models/shift_change.py:0
 #, python-format
 msgid "You can't change a shift to which your are not assigned."
-msgstr ""
+msgstr "Vous ne pouvez pas changer un shift auquel vous n'êtes pas assigné."
 
 #. module: shift_change
 #. odoo-python
@@ -243,6 +258,7 @@ msgstr ""
 msgid ""
 "You can't change the same shift more than %(same_shift_change_max)s times."
 msgstr ""
+"Vous ne pouvez pas changer un shift plus de %(same_shift_change_max)s fois."
 
 #. module: shift_change
 #. odoo-python
@@ -250,13 +266,14 @@ msgstr ""
 #, python-format
 msgid "You can't subscribe to a shift assigned to someone else."
 msgstr ""
+"Vous ne pouvez pas vous inscrire à un shift assigné à quelqu'un d'autre."
 
 #. module: shift_change
 #. odoo-python
 #: code:addons/shift_change/models/shift_change.py:0
 #, python-format
 msgid "You can't subscribe to a shift in the past."
-msgstr ""
+msgstr "Vous ne pouvez pas vous inscrire à un shift qui est dans le passé."
 
 #. module: shift_change
 #. odoo-python
@@ -264,6 +281,7 @@ msgstr ""
 #, python-format
 msgid "You can't subscribe to a shift that is so close in the future."
 msgstr ""
+"Vous ne pouvez pas vous inscrire à un shift qui est si proche dans le temps."
 
 #. module: shift_change
 #. odoo-python
@@ -271,3 +289,5 @@ msgstr ""
 #, python-format
 msgid "You can't subscribe to this shift, it's not available to you."
 msgstr ""
+"Vous ne pouvez pas vous inscrire à ce shift, il n'est pas disponible pour "
+"vous."

--- a/shift_change/models/res_partner.py
+++ b/shift_change/models/res_partner.py
@@ -10,7 +10,7 @@ class ResPartner(models.Model):
 
     def button_change_shift(self):
         return {
-            "name": _("Change a shift"),
+            "name": _("Change a Shift"),
             "type": "ir.actions.act_window",
             "view_type": "form",
             "view_mode": "form",

--- a/shift_change/models/shift_change.py
+++ b/shift_change/models/shift_change.py
@@ -190,7 +190,7 @@ class ShiftChange(models.Model):
     @api.model
     def _check_new_shift(self, new_shift_id, worker_id):
         """Check if shift can be changed or not"""
-        old_shift_hour_limit_change = self._get_old_shift_hour_limit_change()
+        new_shift_hour_limit_change = self._get_new_shift_hour_limit_change()
         if new_shift_id.worker_id:
             raise ValidationError(
                 _("You can't subscribe to a shift assigned to someone else.")
@@ -198,7 +198,7 @@ class ShiftChange(models.Model):
         if new_shift_id.start_time <= datetime.now():
             raise ValidationError(_("You can't subscribe to a shift in the past."))
         if new_shift_id.start_time <= datetime.now() + timedelta(
-            hours=old_shift_hour_limit_change
+            hours=new_shift_hour_limit_change
         ):
             raise ValidationError(
                 _("You can't subscribe to a shift so close in the futur.")

--- a/shift_change/models/shift_change.py
+++ b/shift_change/models/shift_change.py
@@ -23,10 +23,10 @@ class ShiftChange(models.Model):
         ],
         required=True,
     )
-    old_shift_id = fields.Many2one("shift.shift", string="Old shift", required=True)
+    old_shift_id = fields.Many2one("shift.shift", string="Old Shift", required=True)
     new_shift_id = fields.Many2one(
         "shift.shift",
-        string="New shift",
+        string="New Shift",
         required=True,
     )
 
@@ -144,13 +144,17 @@ class ShiftChange(models.Model):
         """Check if old shift can be changed"""
         old_shift_hour_limit_change = self._get_old_shift_hour_limit_change()
         if not old_shift_id.worker_id or old_shift_id.worker_id != worker_id:
-            raise ValidationError(_("You can't change shift that your are not worker."))
+            raise ValidationError(
+                _("You can't change a shift to which your are not assigned.")
+            )
         if old_shift_id.start_time <= datetime.now():
-            raise ValidationError(_("You can't change shift that is in the past."))
+            raise ValidationError(_("You can't change a shift that is in the past."))
         if old_shift_id.start_time <= datetime.now() + timedelta(
             hours=old_shift_hour_limit_change
         ):
-            raise ValidationError(_("You can't change a shift so close in the futur."))
+            raise ValidationError(
+                _("You can't change a shift that is so close in the future.")
+            )
         try:
             same_shift_change_max = int(
                 self.env["ir.config_parameter"]
@@ -183,7 +187,8 @@ class ShiftChange(models.Model):
                 raise ValidationError(
                     _(
                         "You can't change the same shift more than "
-                        f"{same_shift_change_max} times."
+                        "%(same_shift_change_max)s times.",
+                        same_shift_change_max=same_shift_change_max,
                     )
                 )
 
@@ -201,9 +206,9 @@ class ShiftChange(models.Model):
             hours=new_shift_hour_limit_change
         ):
             raise ValidationError(
-                _("You can't subscribe to a shift so close in the futur.")
+                _("You can't subscribe to a shift that is so close in the future.")
             )
         if new_shift_id not in self._get_available_new_shift_ids(worker_id):
             raise ValidationError(
-                _("You can't subscribe to this shift, it’s not available for you.")
+                _("You can't subscribe to this shift, it's not available to you.")
             )

--- a/shift_change/views/res_config_setting_view.xml
+++ b/shift_change/views/res_config_setting_view.xml
@@ -41,7 +41,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                             </div>
 
                             <span class="o_form_label">
-                                Time limit to take a new a shift
+                                Time limit to take a new shift
                             </span>
                             <div class="text-muted">
                                 Number of hours below which a new shift cannot be taken

--- a/shift_change/views/res_partner.xml
+++ b/shift_change/views/res_partner.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
             <xpath expr="//header/button[@name='temporary_exempt']" position="after">
                 <button
                     name="button_change_shift"
-                    string="Change a shift"
+                    string="Change a Shift"
                     class="oe_highlight"
                     type="object"
                     groups="shift.group_shift_management"

--- a/shift_change/views/shift_change_menu.xml
+++ b/shift_change/views/shift_change_menu.xml
@@ -8,13 +8,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later
     <!-- Action to open change shift -->
 
     <record model="ir.actions.act_window" id="action_shift_change">
-        <field name="name">Shift changes</field>
+        <field name="name">Shift Changes</field>
         <field name="res_model">shift.change</field>
         <field name="view_mode">tree,form</field>
     </record>
 
     <record model="ir.actions.act_window" id="action_shift_change_create_wizard">
-        <field name="name">Shift Change Create Wizard</field>
+        <field name="name">Create Shift Change</field>
         <field name="res_model">shift.change.create.wizard</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>

--- a/shift_change/wizard/shift_change_create_wizard.py
+++ b/shift_change/wizard/shift_change_create_wizard.py
@@ -23,10 +23,10 @@ class ShiftChangeCreateWizard(models.TransientModel):
         ),
         required=True,
     )
-    old_shift_id = fields.Many2one("shift.shift", string="Old shift", required=True)
+    old_shift_id = fields.Many2one("shift.shift", string="Old Shift", required=True)
     new_shift_id = fields.Many2one(
         "shift.shift",
-        string="New shift",
+        string="New Shift",
         required=True,
     )
     available_new_shift_ids = fields.Many2many(


### PR DESCRIPTION
## Description

Check if the shift we're changing to is under the time limit to change shift. 
Instead of checking with the start time of the shift we're changing from.

## Odoo task (if applicable)

[16757](https://gestion.coopiteasy.be/web#view_type=form&model=project.task&id=16757&active_id=16757&menu_id=)

## Checklist before approval

- [x] Tests are present (or not needed).
- [x] Credits/copyright have been changed correctly.
- [x] Change log snippet is present.
- [x] (If a new module) Moving this to OCA has been considered.
